### PR TITLE
Adds caching .UTF-8..

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -505,7 +505,7 @@ class Channel(SlackThing):
         if time != 0 and self.last_read >= time:
             tags = "no_highlight,notify_none,logger_backlog_end"
             set_read_marker = True
-        elif message.find(self.server.nick) > -1:
+        elif message.find(self.server.nick.encode('utf-8')) > -1:
             tags = "notify_highlight"
         elif user != self.server.nick and self.name in self.server.users:
             tags = "notify_private,notify_message"

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -727,14 +727,12 @@ def command_markread(current_buffer, args):
         servers.find(domain).channels.find(channel).mark_read()
 
 def command_cacheinfo(current_buffer, args):
-    # refactor this - one liner i think
     for channel in message_cache.keys():
         c = channels.find(channel)
         w.prnt("", "{} {}".format(channels.find(channel), len(message_cache[channel])))
 #        server.buffer_prnt("{} {}".format(channels.find(channel), len(message_cache[channel])))
 
 def command_uncache(current_buffer, args):
-    # refactor this - one liner i think
     identifier = channels.find(current_buffer).identifier
     message_cache.pop(identifier)
     cache_write_cb("","")


### PR DESCRIPTION
#### Cache backlog messages locally. This makes startup much faster.
Default location is ~/.weechat/slack.cache
Saved every 5 minutes to avoid excessive writes
`/slack cacheinfo` shows # of messages in in-memory copy
`/slack cachenow` saves the cache to disk immediately
`/slack uncache` removes the current channel from the in memory cache AND saves to disk immediately
#### add some utf-8 stuff (thanks bchretien)
¯\_(ツ)_/¯ and whatnot shoudl work now. there are likely bugs here, so open an issue if you see any.
#### removed all of the queueing craziness
this was a workaround for weechat returning incomplete data when calling curl (even the internal libcurl)
dropping support for weechat < 1.1