### PR TITLE
Handle JSON decoding errors

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1467,7 +1467,7 @@ if __name__ == "__main__":
         try:
             cache_file = open("{}/{}".format(WEECHAT_HOME, CACHE_NAME), 'r')
             message_cache = json.loads(cache_file.read())
-        except IOError:
+        except (IOError, ValueError):
             message_cache = {}
         # End global var section
 


### PR DESCRIPTION
JSON decoding errors raise ValueError instead of IOError. In such
cases, the best is to just act as if there was no cache previously.

Signed-off-by: Antoni Segura Puimedon <toni@midokura.com>