### PR TITLE
Fix buffers.pl hotlist colors

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -519,10 +519,9 @@ class Channel(SlackThing):
 
     def rename(self):
         if current_domain_name() != self.server.domain and channels_not_on_current_server_color:
-            color = channels_not_on_current_server_color
+            color = w.color(channels_not_on_current_server_color)
         else:
-            color = "default"
-        color = w.color(color)
+            color = ""
         if self.is_someone_typing():
             new_name = ">{}".format(self.name[1:])
         else:


### PR DESCRIPTION
This fixes the #16 problem for me. 

buffers.pl appears to depend on the color not being set in a channel name in order to properly set the hotlist_* colors. Previously the color was being set to default, this change stops setting any color if channels_not_on_current_server_color isn't set.