### PR TITLE
linkify_text: Add support for "@group" and "@channel".

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -456,6 +456,8 @@ class Channel(SlackThing):
         for item in enumerate(message):
             if item[1].startswith('@'):
                 named = re.match('.*[@#](\w+)(\W*)', item[1]).groups()
+                if named[0] in ["group", "channel"]:
+                    message[item[0]] = "<!{}>".format(named[0])
                 if self.server.users.find(named[0]):
                     message[item[0]] = "<@{}>{}".format(self.server.users.find(named[0]).identifier, named[1])
             if item[1].startswith('#') and self.server.channels.find(item[1]):


### PR DESCRIPTION
These two commands are aliases for one another, and should work in both
private and public channels in Slack. Technically, there's also an
!everyone command, but that isn't implemented here.