### PR TITLE
Typo in process_channel_archive

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1179,7 +1179,10 @@ def process_im_created(message_json):
 
 def process_user_typing(message_json):
     server = servers.find(message_json["myserver"])
-    server.channels.find(message_json["channel"]).set_typing(server.users.find(message_json["user"]).name)
+    channel = server.channels.find(message_json["channel"])
+    if channel:
+        channel.set_typing(server.users.find(message_json["user"]).name)
+
 
 # todo: does this work?
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1124,6 +1124,7 @@ def process_channel_leave(message_json):
 
 
 def  process_channel_archive(message_json):
+    server = servers.find(message_json["myserver"])
     channel = server.channels.find(message_json["channel"])
     channel.detach_buffer()
 


### PR DESCRIPTION
process_channel_archive failed to look up the server before
referencing it, leading to backtraces.