### PR TITLE
Improve nick completion

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1481,6 +1481,57 @@ def slack_never_away_cb(data, remaining):
             server.send_to_websocket(request, expect_reply=False)
     return w.WEECHAT_RC_OK
 
+
+def nick_completion_cb(data, completion_item, buffer, completion):
+    """
+    Adds all @-prefixed nicks to completion list
+    """
+
+    channel = channels.find(buffer)
+    for m in channel.members:
+        user = channel.server.users.find(m)
+        w.hook_completion_list_add(completion, "@" + user.name, 1, w.WEECHAT_LIST_POS_SORT)
+    return w.WEECHAT_RC_OK
+
+
+def complete_next_cb(data, buffer, command):
+    """Extract current word, if it is equal to a nick, prefix it with @ and
+    rely on nick_completion_cb adding the @-prefixed versions to the
+    completion lists, then let Weechat's internal completion do its
+    thing
+
+    """
+
+    channel = channels.find(buffer)
+    if channel is None or channel.members is None:
+        return w.WEECHAT_RC_OK
+    input = w.buffer_get_string(buffer, "input")
+    current_pos = w.buffer_get_integer(buffer, "input_pos") - 1
+    input_length = w.buffer_get_integer(buffer, "input_length")
+    word_start = 0
+    word_end = input_length
+    # If we're on a non-word, look left for something to complete
+    while current_pos >= 0 and input[current_pos] != '@' and not input[current_pos].isalnum():
+        current_pos = current_pos - 1
+    for l in range(current_pos, 0, -1):
+        if input[l] != '@' and not input[l].isalnum():
+            word_start = l + 1
+            break
+    for l in range(current_pos, input_length):
+        if not input[l].isalnum():
+            word_end = l
+            break
+    word = input[word_start:word_end]
+    for m in channel.members:
+        user = channel.server.users.find(m)
+        if user.name == word:
+            # Here, we cheat.  Insert a @ in front and rely in the @
+            # nicks being in the completion list
+            w.buffer_set(buffer, "input", input[:word_start] + "@" + input[word_start:])
+            w.buffer_set(buffer, "input_pos", str(w.buffer_get_integer(buffer, "input_pos") + 1))
+            return w.WEECHAT_RC_OK_EAT
+    return w.WEECHAT_RC_OK
+
 # Slack specific requests
 
 # NOTE: switched to async/curl because sync slowed down the UI
@@ -1728,5 +1779,8 @@ if __name__ == "__main__":
         w.hook_command_run('/join', 'join_command_cb', '')
         w.hook_command_run('/part', 'part_command_cb', '')
         w.hook_command_run('/leave', 'part_command_cb', '')
+        w.hook_command_run("/input complete_next", "complete_next_cb", "")
+        w.hook_completion("nicks", "complete @-nicks for slack",
+                          "nick_completion_cb", "")
         w.bar_item_new('slack_typing_notice', 'typing_bar_item_cb', '')
         # END attach to the weechat hooks we need


### PR DESCRIPTION
Previously, weechat would not complete @-prefixed nicks, fix that, and
make it so that if you complete on an already-full nick, wee-slack
adds a prefixing @, leading to a slack highlight.