### PR TITLE
support server aliases, so buffer names are shorter

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,11 @@ Turn off colorized nicks:
 /set plugins.var.python.slack_extension.colorize_nicks 0
 ```
 
+Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. when using buffers.pl):
+```
+/set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"
+```
+
 Set all read markers to a specific time:
 ```
 /slack setallreadmarkers (time in epoch)


### PR DESCRIPTION
First off, thank you so much for wee-slack.  It's fantastic.

After I switched to wee-slack, I found that buffers.pl (at least in my configuration) put the slack subdomain in the channel name.  I wanted to trim it down, so instead of this:

![full_name](https://cloud.githubusercontent.com/assets/8082/9565089/ce22220c-4e6f-11e5-974f-d8d5b5cf5d1a.png)

I wanted this:

![shortened](https://cloud.githubusercontent.com/assets/8082/9565092/d6ab868e-4e6f-11e5-8d84-2e6333692f08.png)

I made this change initially back in March when I started using wee-slack and it's been useful to me, so I thought I would share.

Thanks.