### PR TITLE
Add upload capability to slack buffer

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ A WeeChat native client for Slack.com. Provides supplemental features only avail
 
 Features
 --------
-  * **New** Emoji reactions!
+  * **New** Upload to slack capabilities!
+  * Emoji reactions!
   * Edited messages work just like the official clients, where the original message changes and has (edited) appended.
   * Unfurled urls dont generate a new message, but replace the original with more info as it is received.
   * Regex style message editing (s/oldtext/newtext/)
@@ -167,6 +168,11 @@ Turn off colorized nicks:
 Set all read markers to a specific time:
 ```
 /slack setallreadmarkers (time in epoch)
+```
+
+Upload a file to the current slack buffer:
+```
+/slack upload [file_path]
 ```
 
 Debug mode:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -4,6 +4,7 @@
 from functools import wraps
 import time
 import json
+import os
 import pickle
 import sha
 import re
@@ -902,6 +903,26 @@ def slack_buffer_required(f):
 
 
 @slack_buffer_required
+def command_upload(current_buffer, args):
+    """
+    Uploads a file to the current buffer
+    /slack upload [file_path]
+    """
+    post_data = {}
+    channel = current_buffer_name(short=True)
+    domain = current_domain_name()
+    token = servers.find(domain).token
+
+    if servers.find(domain).channels.find(channel):
+        channel_identifier = servers.find(domain).channels.find(channel).identifier
+
+    if channel_identifier:
+        post_data["token"] = token
+        post_data["channels"] = channel_identifier
+        post_data["file"] = args
+        async_slack_api_upload_request(token, "files.upload", post_data)
+
+@slack_buffer_required
 def command_talk(current_buffer, args):
     """
     Open a chat with the specified user
@@ -1718,6 +1739,14 @@ def async_slack_api_request(domain, token, request, post_data, priority=False):
         params = { 'useragent': 'wee_slack {}'.format(SCRIPT_VERSION) }
         dbg("URL: {} context: {} params: {}".format(url, context, params))
         w.hook_process_hashtable(url, params, 20000, "url_processor_cb", context)
+
+def async_slack_api_upload_request(token, request, post_data, priority=False):
+    if not STOP_TALKING_TO_SLACK:
+        url = 'https://slack.com/api/{}'.format(request)
+        file_path = os.path.expanduser(post_data["file"])
+        command = 'curl -F file=@{} -F channels={} -F token={} {}'.format(file_path, post_data["channels"], token, url)
+        context = pickle.dumps({"request": request, "token": token, "post_data": post_data})
+        w.hook_process(command, 20000, "url_processor_cb", context)
 
 # funny, right?
 big_data = {}


### PR DESCRIPTION
This commit:
- Adds the ability to upload a file to the current slack buffer using
  the `/slack upload [file_path]` command

Why?
- This is a very useful feature for people that are trying to fully
  replace the slack web app