### PR TITLE
Stop colouring channels and dmchannels

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -531,17 +531,13 @@ class Channel(object):
         async_slack_api_request(self.server.domain, self.server.token, SLACK_API_TRANSLATOR[self.type]["mark"], {"channel": self.identifier, "ts": time})
 
     def rename(self):
-        if current_domain_name() != self.server.domain and channels_not_on_current_server_color:
-            color = w.color(channels_not_on_current_server_color)
-        else:
-            color = ""
         if self.is_someone_typing():
             new_name = ">{}".format(self.name[1:])
         else:
             new_name = self.name
         if self.channel_buffer:
-            if w.buffer_get_string(self.channel_buffer, "short_name") != (color + new_name):
-                w.buffer_set(self.channel_buffer, "short_name", color + new_name)
+            if w.buffer_get_string(self.channel_buffer, "short_name") != new_name:
+                w.buffer_set(self.channel_buffer, "short_name", new_name)
 
 # deprecated in favor of redrawing the entire buffer
 #    def buffer_prnt_changed(self, user, text, time, append=""):
@@ -683,15 +679,12 @@ class DmChannel(Channel):
         self.type = "im"
 
     def rename(self):
-        if current_domain_name() != self.server.domain and channels_not_on_current_server_color:
-            force_color = w.color(channels_not_on_current_server_color)
-        else:
-            force_color = None
+        global colorize_private_chats
 
         if self.server.users.find(self.name).presence == "active":
-            new_name = self.server.users.find(self.name).formatted_name('+', force_color)
+            new_name = self.server.users.find(self.name).formatted_name('+', colorize_private_chats)
         else:
-            new_name = self.server.users.find(self.name).formatted_name(' ', force_color)
+            new_name = self.server.users.find(self.name).formatted_name(' ', colorize_private_chats)
 
         if self.channel_buffer:
             w.buffer_set(self.channel_buffer, "short_name", new_name)
@@ -766,9 +759,9 @@ class User(object):
             self.color = ""
             self.color_name = ""
 
-    def formatted_name(self, prepend="", force_color=None):
-        if colorize_nicks:
-            print_color = force_color or self.color
+    def formatted_name(self, prepend="", enable_color=True):
+        if colorize_nicks and enable_color:
+            print_color = self.color
         else:
             print_color = ""
         return print_color + prepend + self.name
@@ -1847,7 +1840,7 @@ def create_slack_debug_buffer():
 
 
 def config_changed_cb(data, option, value):
-    global slack_api_token, distracting_channels, channels_not_on_current_server_color, colorize_nicks, slack_debug, debug_mode, \
+    global slack_api_token, distracting_channels, colorize_nicks, colorize_private_chats, slack_debug, debug_mode, \
         unfurl_ignore_alt_text
 
     slack_api_token = w.config_get_plugin("slack_api_token")
@@ -1856,13 +1849,11 @@ def config_changed_cb(data, option, value):
         slack_api_token = w.string_eval_expression(slack_api_token, {}, {}, {})
 
     distracting_channels = [x.strip() for x in w.config_get_plugin("distracting_channels").split(',')]
-    channels_not_on_current_server_color = w.config_get_plugin("channels_not_on_current_server_color")
-    if channels_not_on_current_server_color == "0":
-        channels_not_on_current_server_color = False
     colorize_nicks = w.config_get_plugin('colorize_nicks') == "1"
     debug_mode = w.config_get_plugin("debug_mode").lower()
     if debug_mode != '' and debug_mode != 'false':
         create_slack_debug_buffer()
+    colorize_private_chats = w.config_string_to_boolean(w.config_get_plugin("colorize_private_chats"))
 
     unfurl_ignore_alt_text = False
     if w.config_get_plugin('unfurl_ignore_alt_text') != "0":
@@ -1913,18 +1904,20 @@ if __name__ == "__main__":
             w.config_set_plugin('slack_api_token', "INSERT VALID KEY HERE!")
         if not w.config_get_plugin('distracting_channels'):
             w.config_set_plugin('distracting_channels', "")
-        if not w.config_get_plugin('channels_not_on_current_server_color'):
-            w.config_set_plugin('channels_not_on_current_server_color', "0")
         if not w.config_get_plugin('debug_mode'):
             w.config_set_plugin('debug_mode', "")
         if not w.config_get_plugin('colorize_nicks'):
             w.config_set_plugin('colorize_nicks', "1")
+        if not w.config_get_plugin('colorize_private_chats'):
+            w.config_set_plugin('colorize_private_chats', "0")
         if not w.config_get_plugin('trigger_value'):
             w.config_set_plugin('trigger_value', "0")
         if not w.config_get_plugin('unfurl_ignore_alt_text'):
             w.config_set_plugin('unfurl_ignore_alt_text', "0")
         if not w.config_get_plugin('switch_buffer_on_join'):
             w.config_set_plugin('switch_buffer_on_join', "1")
+
+        w.config_option_unset('channels_not_on_current_server_color')
 
         version = w.info_get("version_number", "") or 0
         if int(version) >= 0x00040400:


### PR DESCRIPTION
The weechat short_name property is a non-coloured string (according to
discussion on #weechat), so don't add any colours to it.

Fixes: #74