### PR TITLE
Only decode messages if they are not already unicode

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -584,7 +584,8 @@ class Channel(object):
             name = name.decode('utf-8')
             #colorize nicks in each line
             chat_color = w.config_string(w.config_get('weechat.color.chat'))
-            message = message.decode('UTF-8', 'replace')
+            if type(message) is not unicode:
+              message = message.decode('UTF-8', 'replace')
             for user in self.server.users:
                 if user.name in message:
                     message = user.name_regex.sub(


### PR DESCRIPTION
Some messages are already of type unicode when sent into buffer_prnt.
This makes message.decode fail with the following error:

    UnicodeEncodeError: 'ascii' codec can't encode character u'\xe5' in
    position 76: ordinal not in range(128)