### PR TITLE
Use weechat for requests instead of curl

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,6 @@ Dependencies
 ------------
   * WeeChat 1.1+ http://weechat.org/ 
   * websocket-client https://pypi.python.org/pypi/websocket-client/
-  * curl http://curl.haxx.se/
 
 Setup
 ------
@@ -65,19 +64,14 @@ wee-slack doesn't use the Slack IRC gateway. If you currently connect via the ga
 
 ####1. Install dependencies
 
-##### OSX
+##### OSX and Linux
 ```
 pip install websocket-client
 ```
 
-##### Linux (ubuntu)
-```
-sudo apt-get install curl
-pip install websocket-client
-```
 ##### FreeBSD
 ```
-pkg install curl py27-websocket-client py27-six
+pkg install py27-websocket-client py27-six
 ```
 
 ####2. copy wee_slack.py to ~/.weechat/python/autoload

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1707,14 +1707,13 @@ def complete_next_cb(data, buffer, command):
 
 # Slack specific requests
 
-# NOTE: switched to async/curl because sync slowed down the UI
+# NOTE: switched to async because sync slowed down the UI
 def async_slack_api_request(domain, token, request, post_data, priority=False):
     if not STOP_TALKING_TO_SLACK:
         post_data["token"] = token
         url = 'https://{}/api/{}'.format(domain, request)
-        command = 'curl  -A "wee_slack {}" -s --data "{}" {}'.format(SCRIPT_VERSION, urllib.urlencode(post_data), url)
         context = pickle.dumps({"request": request, "token": token, "post_data": post_data})
-        w.hook_process(command, 20000, "url_processor_cb", context)
+        w.hook_process("url:{}?{}".format(url, urllib.urlencode(post_data)), 20000, "url_processor_cb", context)
 
 # funny, right?
 big_data = {}
@@ -1730,8 +1729,8 @@ def url_processor_cb(data, command, return_code, out, err):
         try:
             my_json = json.loads(big_data[identifier])
         except:
-            dbg("curl failed, doing again...")
-            dbg("curl length: {} identifier {}\n{}".format(len(big_data[identifier]), identifier, data))
+            dbg("request failed, doing again...")
+            dbg("response length: {} identifier {}\n{}".format(len(big_data[identifier]), identifier, data))
             my_json = False
 
         big_data.pop(identifier, None)


### PR DESCRIPTION
Weechat has (since version 0.3.7) a builtin method for plugins to
download from URLs. This commit replaces the use of the curl command
with this. There are two main reasons for doing this:

 - When using an external command, the arguments are visible to all
   users of the machine, including the token for connecting to Slack.
 - It removes the need to depend on curl.

This also makes #78 unnecessary.