### PR TITLE
lots of refactoring for efficiency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ wee-slack
 =========
 
 **News:**
- The 0.98.3+ releases have some big backend changes that should make startup and multi-group much faster. Please report any bugs to the Freenode IRC channel #wee-slack.
+ The 0.99.1+ has a number of backend changes to make things faster and better. You should use it. :) _(please report bugs in #wee-slack on freenode)_
 
 A WeeChat native client for Slack.com. Provides supplemental features only available in the web/mobile clients such as: synchronizing read markers, typing notification, search, (and more)! Connects via the Slack API, and maintains a persistent websocket for notification of events.
 

--- a/_pytest/conftest.py
+++ b/_pytest/conftest.py
@@ -1,7 +1,8 @@
 import pytest
 import sys
 
-sys.path.append(str(pytest.config.rootdir))
+sys.path.append(".")
+#sys.path.append(str(pytest.config.rootdir))
 
 from wee_slack import SlackServer
 from wee_slack import Channel

--- a/_pytest/data/message-changed.json
+++ b/_pytest/data/message-changed.json
@@ -15,5 +15,5 @@
       }
     },
 
-    "myserver": "test.slack.com"
+    "_server": "test.slack.com"
 }

--- a/_pytest/data/message-deleted.json
+++ b/_pytest/data/message-deleted.json
@@ -5,5 +5,5 @@
     "channel": "C2147483705",
     "ts": "1358878755.000001",
     "deleted_ts": "1355517519.000005",
-    "myserver": "test.slack.com"
+    "_server": "test.slack.com"
 }

--- a/_pytest/data/message-normal.json
+++ b/_pytest/data/message-normal.json
@@ -4,5 +4,5 @@
     "user": "U2147483697",
     "text": "Hello world",
     "ts": "1355517523.000005",
-    "myserver": "test.slack.com"
+    "_server": "test.slack.com"
 }

--- a/_pytest/data/message-normal2.json
+++ b/_pytest/data/message-normal2.json
@@ -4,5 +4,5 @@
     "user": "U2147483697",
     "text": "A Second message!",
     "ts": "1355517524.000005",
-    "myserver": "test.slack.com"
+    "_server": "test.slack.com"
 }

--- a/_pytest/test_process_message.py
+++ b/_pytest/test_process_message.py
@@ -30,6 +30,8 @@ def test_process_message(slack_debug, monkeypatch, myservers, mychannels, myuser
     messages.append( json.loads(open('_pytest/data/message-deleted.json', 'r').read()) )
     for m in messages:
         wee_slack.process_message(m)
+    print "---"
     print called
+    print "---"
 #    assert called['buffer_prnt'] == 2
 #    assert called['buffer_prnt_changed'] == 1

--- a/_pytest/test_unfurl.py
+++ b/_pytest/test_unfurl.py
@@ -25,7 +25,7 @@ unfurl_map = [
       "output": "url: https://example.com (example with spaces) suffix",
     },
     ]
-    
+
 
 def test_unfurl_refs(myservers, mychannels, myusers):
     slack.servers = myservers
@@ -34,7 +34,7 @@ def test_unfurl_refs(myservers, mychannels, myusers):
     slack.message_cache = {}
     slack.servers[0].users = myusers
     print mychannels[0].identifier
-    
+
     for k in unfurl_map:
         if "ignore_alt_text" in k:
             assert slack.unfurl_refs(k["input"], ignore_alt_text=k["ignore_alt_text"]) == k["output"]

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1417,7 +1417,7 @@ def render_message(message_json):
         if "reactions" in message_json:
             text += create_reaction_string(message_json["reactions"])
 
-        w.prnt("", "rendered message")
+        #w.prnt("", "rendered message")
         return text
 
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -295,6 +295,8 @@ class SlackServer(object):
         for item in data["ims"]:
             if "last_read" not in item:
                 item["last_read"] = 0
+            if item["unread_count"] > 0:
+                item["is_open"] = True
             name = self.users.find(item["user"]).name
             self.add_channel(DmChannel(self, name, item["id"], item["is_open"], item["last_read"]))
         for item in data['self']['prefs']['muted_channels'].split(','):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -222,7 +222,7 @@ class SlackServer(object):
                     w.unhook(self.ping_hook)
                     self.communication_counter = 0
                 self.ping_hook = w.hook_timer(1000 * 5, 0, 0, "slack_ping_cb", self.domain)
-                if len(self.users) and 0 or len(self.channels) == 0:
+                if len(self.users) == 0 or len(self.channels) == 0:
                     self.create_slack_mappings(login_data)
 
                 self.connected = True
@@ -1190,6 +1190,7 @@ def slack_websocket_cb(server, fd):
         # this magic attaches json that helps find the right dest
         message_json['_server'] = server
     except:
+        servers.find(server).ws.close()
         return w.WEECHAT_RC_OK
     # dispatch here
     if "reply_to" in message_json:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -13,7 +13,7 @@ import HTMLParser
 import sys
 import traceback
 import collections
-from websocket import create_connection
+from websocket import create_connection,WebSocketConnectionClosedException
 
 # hack to make tests possible.. better way?
 try:
@@ -1189,8 +1189,11 @@ def slack_websocket_cb(server, fd):
         message_json = json.loads(data)
         # this magic attaches json that helps find the right dest
         message_json['_server'] = server
-    except:
+    except WebSocketConnectionClosedException:
         servers.find(server).ws.close()
+        return w.WEECHAT_RC_OK
+    except Exception:
+        dbg("socket issue: {}\n".format(traceback.format_exc()))
         return w.WEECHAT_RC_OK
     # dispatch here
     if "reply_to" in message_json:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -766,7 +766,9 @@ class User(object):
             if channel.has_user(self.identifier):
                 channel.update_nicklist()
         w.nicklist_nick_set(self.server.buffer, self.nicklist_pointer, "visible", "1")
-        buffer_list_update_next()
+        dm_channel = self.server.channels.find(self.name)
+        if dm_channel and dm_channel.active:
+            buffer_list_update_next()
 
     def set_inactive(self):
         self.presence = "away"
@@ -774,7 +776,9 @@ class User(object):
             if channel.has_user(self.identifier):
                 channel.update_nicklist()
         w.nicklist_nick_set(self.server.buffer, self.nicklist_pointer, "visible", "0")
-        buffer_list_update_next()
+        dm_channel = self.server.channels.find(self.name)
+        if dm_channel and dm_channel.active:
+            buffer_list_update_next()
 
     def update_color(self):
         if colorize_nicks:
@@ -1609,6 +1613,7 @@ def buffer_list_update_cb(data, remaining_calls):
 
     now = time.time()
     if buffer_list_update and previous_buffer_list_update + 1 < now:
+        w.prnt("", "updated buffer list...")
         gray_check = False
         if len(servers) > 1:
             gray_check = True
@@ -1639,7 +1644,7 @@ def buffer_closing_cb(signal, sig_type, data):
 def buffer_switch_cb(signal, sig_type, data):
     global previous_buffer, hotlist
     # this is to see if we need to gray out things in the buffer list
-    buffer_list_update_next()
+    # buffer_list_update_next()
     if channels.find(previous_buffer):
         channels.find(previous_buffer).mark_read()
 
@@ -2011,7 +2016,7 @@ if __name__ == "__main__":
 
         # attach to the weechat hooks we need
         w.hook_timer(1000, 0, 0, "typing_update_cb", "")
-        w.hook_timer(1000, 0, 0, "buffer_list_update_cb", "")
+        w.hook_timer(3000, 0, 0, "buffer_list_update_cb", "")
         w.hook_timer(1000, 0, 0, "hotlist_cache_update_cb", "")
         w.hook_timer(1000 * 60 * 29, 0, 0, "slack_never_away_cb", "")
         w.hook_timer(1000 * 60 * 5, 0, 0, "cache_write_cb", "")

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -912,6 +912,8 @@ def me_command_cb(data, current_buffer, args):
 
 
 def join_command_cb(data, current_buffer, args):
+    user = args.split()[1]
+    servers.find(current_domain_name()).users.find(user).open()
     if channels.find(current_buffer) or servers.find(current_buffer):
         channel = args.split()[1]
         channel = servers.find(current_domain_name()).channels.find(channel)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -385,7 +385,6 @@ class Channel(object):
                 w.buffer_set(self.channel_buffer, "localvar_set_type", 'private')
             else:
                 w.buffer_set(self.channel_buffer, "localvar_set_type", 'channel')
-            #w.buffer_set(self.channel_buffer, "short_name", 'loading..')
             w.buffer_set(self.channel_buffer, "short_name", self.name)
             buffer_list_update_next()
 
@@ -535,7 +534,7 @@ class Channel(object):
                 return True
         if len(self.typing) > 0:
             self.typing = {}
-            #buffer_list_update_next()
+            buffer_list_update_next()
         return False
 
     def get_typing_list(self):
@@ -570,19 +569,6 @@ class Channel(object):
             if self.current_short_name != (color + new_name):
                 self.current_short_name = color + new_name
                 w.buffer_set(self.channel_buffer, "short_name", color + new_name)
-
-# deprecated in favor of redrawing the entire buffer
-#    def buffer_prnt_changed(self, user, text, time, append=""):
-#        if self.channel_buffer:
-#            if user:
-#                if self.server.users.find(user):
-#                    name = self.server.users.find(user).formatted_name()
-#                else:
-#                    name = user
-#                name = name.decode('utf-8')
-#                modify_buffer_line(self.channel_buffer, name, text, time, append)
-#            else:
-#                modify_buffer_line(self.channel_buffer, None, text, time, append)
 
     def buffer_prnt(self, user='unknown_user', message='no message', time=0):
         """
@@ -1367,7 +1353,6 @@ def process_user_typing(message_json):
 
 def process_error(message_json):
     pass
-    #connected = False
 
 def process_reaction_added(message_json):
     if message_json["item"].get("type") == "message":
@@ -1666,7 +1651,6 @@ def buffer_closing_cb(signal, sig_type, data):
 def buffer_switch_cb(signal, sig_type, data):
     global previous_buffer, hotlist
     # this is to see if we need to gray out things in the buffer list
-    # buffer_list_update_next()
     if channels.find(previous_buffer):
         channels.find(previous_buffer).mark_read()
 
@@ -1844,7 +1828,6 @@ def cache_load():
     global message_cache
     try:
         file_name = "{}/{}".format(WEECHAT_HOME, CACHE_NAME)
-        #if sum(1 for line in open('myfile.txt')) > 2:
         cache_file = open(file_name, 'r')
         if cache_file.readline() == CACHE_VERSION + "\n":
             dbg("Loading messages from cache.", main_buffer=True)
@@ -1854,7 +1837,6 @@ def cache_load():
             dbg("Completed loading messages from cache.", main_buffer=True)
     except IOError:
         w.prnt("", "cache file not found")
-        #cache file didn't exist
         pass
 
 # END Slack specific requests

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1408,6 +1408,10 @@ def modify_buffer_line(buffer, new_line, time):
 
 def render_message(message_json):
         server = servers.find(message_json["myserver"])
+
+        # move message properties down to root of json object
+        message_json = unwrap_message(message_json)
+
         if "fallback" in message_json:
             text = message_json["fallback"]
         elif "text" in message_json:
@@ -1443,8 +1447,6 @@ def process_message(message_json, cache=True):
         if "subtype" in message_json and message_json["subtype"] in known_subtypes:
             proc[message_json["subtype"]](message_json)
 
-        # move message properties down to root of json object
-        message_json = unwrap_message(message_json)
 
         server = servers.find(message_json["myserver"])
         channel = channels.find(message_json["channel"])

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1499,8 +1499,11 @@ def process_message_changed(message_json):
             else:
                 message_json["fallback"] = m["fallback"]
 
+    m["text"] += unwrap_attachments(message_json)
     channel = channels.find(message_json["channel"])
-    channel.change_message(m["ts"], m["text"] + " (edited)")
+    if "edited" in m:
+        m["text"] += " (edited)"
+    channel.change_message(m["ts"], m["text"])
 
 
 def process_message_deleted(message_json):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -829,6 +829,7 @@ class Message(object):
         self.ts = message_json['ts']
         #split timestamp into time and counter
         self.ts_time, self.ts_counter = message_json['ts'].split('.')
+        self.rendered_text = ""
 
     def change_text(self, new_text):
         if not isinstance(new_text, unicode):
@@ -1500,15 +1501,14 @@ def process_message(message_json, cache=True):
         if "reactions" in message_json:
             text += create_reaction_string(message_json["reactions"])
 
-        if "subtype" in message_json and message_json["subtype"] == "message_changed":
+        if message_json.get("subtype", "") == "message_changed":
                 if "edited" in message_json["message"]:
                     append = " (edited)"
                 else:
                     append = ''
                 channel.change_message(message_json["message"]["ts"], text + append)
                 cache=False
-
-        elif "subtype" in message_json and message_json["subtype"] == "message_deleted":
+        elif message_json.get("subtype", "") == "message_deleted":
             append = "(deleted)"
             text = ""
             channel.change_message(message_json["deleted_ts"], text + append)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -633,16 +633,17 @@ class Channel(object):
             if text is not None:
                 self.messages[message_index].change_text(text)
             else:
-                text = self.messages[message_index].message_json["text"]
+                text = render_message(self.messages[message_index].message_json)
+                #text = self.messages[message_index].message_json["text"]
 
             #render reactions if we have any
-            react = create_reaction_string(self.messages[message_index].message_json["reactions"])
+            #react = create_reaction_string(self.messages[message_index].message_json["reactions"])
 
             #if there is only one message with this timestamp, modify it directly.
             #we do this because time resolution in weechat is less than slack
             int_time = int(float(ts))
             if self.messages.count(str(int_time)) == 1:
-                modify_buffer_line(self.channel_buffer, text + react, int_time)
+                modify_buffer_line(self.channel_buffer, text, int_time)
             #otherwise redraw the whole buffer, which is expensive
             else:
                 self.buffer_redraw()
@@ -1399,6 +1400,57 @@ def modify_buffer_line(buffer, new_line, time):
             line_pointer = w.hdata_move(struct_hdata_line, line_pointer, -1)
     return w.WEECHAT_RC_OK
 
+def render_message(message_json, cache=True):
+    try:
+        message_json = unwrap_message(message_json)
+
+        server = servers.find(message_json["myserver"])
+        channel = channels.find(message_json["channel"])
+
+        #do not process messages in unexpected channels
+        if not channel.active:
+            channel.open(False)
+            dbg("message came for closed channel {}".format(channel.name))
+            return
+
+        time = message_json['ts']
+        if "fallback" in message_json:
+            text = message_json["fallback"]
+        elif "text" in message_json:
+            if message_json['text'] is not None:
+                text = message_json["text"]
+            else:
+                text = ""
+        else:
+            text = ""
+
+        #text = text.decode('utf-8')
+
+        text = unfurl_refs(text, ignore_alt_text=unfurl_ignore_alt_text)
+
+        if "attachments" in message_json:
+            text += u" --- {}".format(unwrap_attachments(message_json))
+        text = text.lstrip()
+        text = text.replace("\t", "    ")
+        name = get_user(message_json, server)
+
+        text = text.encode('utf-8')
+        name = name.encode('utf-8')
+
+        if "reactions" in message_json:
+            text += create_reaction_string(message_json["reactions"])
+
+        w.prnt("", "rendered message")
+        return text
+
+
+
+
+    except Exception:
+        if channel and ("text" in message_json) and message_json['text'] is not None:
+            channel.buffer_prnt('unknown', message_json['text'])
+        dbg("cannot process message {}\n{}".format(message_json, traceback.format_exc()))
+
 
 def process_message(message_json, cache=True):
     global unfurl_ignore_alt_text
@@ -1455,6 +1507,7 @@ def process_message(message_json, cache=True):
                     append = ''
                 channel.change_message(message_json["message"]["ts"], text + append)
                 cache=False
+
         elif "subtype" in message_json and message_json["subtype"] == "message_deleted":
             append = "(deleted)"
             text = ""

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -835,7 +835,6 @@ class Message(object):
         self.ts = message_json['ts']
         #split timestamp into time and counter
         self.ts_time, self.ts_counter = message_json['ts'].split('.')
-        self.rendered_text = ""
 
     def change_text(self, new_text):
         if not isinstance(new_text, unicode):
@@ -1459,9 +1458,15 @@ def process_message(message_json, cache=True):
             dbg("message came for closed channel {}".format(channel.name))
             return
 
-        text = render_message(message_json)
 
-        message_json['rendered_text'] = text
+        if message_json.get("rendered_text", ""):
+            text = message_json["rendered_text"]
+            #w.prnt("", "used rendered version..")
+        else:
+            text = render_message(message_json)
+            message_json['rendered_text'] = text
+            #w.prnt("", "no version..")
+
 
         time = message_json['ts']
         name = get_user(message_json, server)
@@ -1830,11 +1835,12 @@ def cache_load():
     global message_cache
     try:
         file_name = "{}/{}".format(WEECHAT_HOME, CACHE_NAME)
-        if sum(1 for line in open('myfile.txt')) > 2:
-            cache_file = open(file_name, 'r')
-            for line in cache_file:
-                message_cache.append(line)
+        #if sum(1 for line in open('myfile.txt')) > 2:
+        cache_file = open(file_name, 'r')
+        for line in cache_file:
+            message_cache.append(line)
     except IOError:
+        w.prnt("", "cache file not found")
         #cache file didn't exist
         pass
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1425,6 +1425,9 @@ def render_message(message_json):
             text += u" --- {}".format(unwrap_attachments(message_json))
         text = text.lstrip()
         text = text.replace("\t", "    ")
+
+        text = text.encode('utf-8')
+
         if "reactions" in message_json:
             text += create_reaction_string(message_json["reactions"])
 
@@ -1436,9 +1439,9 @@ def render_message(message_json):
 
 
 def process_message(message_json, cache=True):
-        global unfurl_ignore_alt_text
+    global unfurl_ignore_alt_text
 
-#    try:
+    try:
         # send these messages elsewhere
         known_subtypes = ['channel_join', 'channel_leave', 'channel_topic']
         if "subtype" in message_json and message_json["subtype"] in known_subtypes:
@@ -1458,11 +1461,12 @@ def process_message(message_json, cache=True):
 
         text = render_message(message_json)
 
+        message_json['rendered_text'] = text
+
         time = message_json['ts']
         name = get_user(message_json, server)
-
-        text = text.encode('utf-8')
         name = name.encode('utf-8')
+
 
 
         if message_json.get("subtype", "") == "message_changed" and "edited" in message_json["message"]:
@@ -1483,10 +1487,10 @@ def process_message(message_json, cache=True):
         if cache:
             channel.cache_message(message_json)
 
-#    except Exception:
-#        if channel and ("text" in message_json) and message_json['text'] is not None:
-#            channel.buffer_prnt('unknown', message_json['text'])
-#        dbg("cannot process message {}\n{}".format(message_json, traceback.format_exc()))
+    except Exception:
+        if channel and ("text" in message_json) and message_json['text'] is not None:
+            channel.buffer_prnt('unknown', message_json['text'])
+        dbg("cannot process message {}\n{}".format(message_json, traceback.format_exc()))
 
 def unwrap_message(message_json):
     if "message" in message_json:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -26,7 +26,7 @@ SCRIPT_LICENSE = "MIT"
 SCRIPT_DESC = "Extends weechat for typing notification/search/etc on slack.com"
 
 BACKLOG_SIZE = 200
-SCROLLBACK_SIZE = 2000
+SCROLLBACK_SIZE = 500
 
 SLACK_API_TRANSLATOR = {
     "channel": {
@@ -1432,9 +1432,6 @@ def render_message(message_json):
 
         #w.prnt("", "rendered message")
         return text
-
-
-
 
 
 def process_message(message_json, cache=True):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1200,7 +1200,6 @@ def process_pong(message_json):
 
 
 def process_pref_change(message_json):
-    w.prnt("", str(message_json))
     server = servers.find(message_json["_server"])
     if message_json['name'] == u'muted_channels':
         muted = message_json['value'].split(',')
@@ -1622,7 +1621,7 @@ def buffer_list_update_cb(data, remaining_calls):
 
     now = time.time()
     if buffer_list_update and previous_buffer_list_update + 1 < now:
-        w.prnt("", "updated buffer list...")
+        dbg("updated buffer list...", main_buffer=True)
         gray_check = False
         if len(servers) > 1:
             gray_check = True

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -446,15 +446,17 @@ class Channel(object):
         self.active = False
 
     def set_typing(self, user):
-        self.typing[user] = time.time()
-        buffer_list_update_next()
+        if w.buffer_get_integer(self.channel_buffer, "hidden") == 0:
+            self.typing[user] = time.time()
+            buffer_list_update_next()
 
     def unset_typing(self, user):
-        try:
-            del self.typing[user]
-            buffer_list_update_next()
-        except:
-            pass
+        if w.buffer_get_integer(self.channel_buffer, "hidden") == 0:
+            try:
+                del self.typing[user]
+                buffer_list_update_next()
+            except:
+                pass
 
     def send_message(self, message):
         message = self.linkify_text(message)
@@ -514,7 +516,7 @@ class Channel(object):
                 return True
         if len(self.typing) > 0:
             self.typing = {}
-            buffer_list_update_next()
+            #buffer_list_update_next()
         return False
 
     def get_typing_list(self):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -22,7 +22,7 @@ except:
 
 SCRIPT_NAME = "slack_extension"
 SCRIPT_AUTHOR = "Ryan Huber <rhuber@gmail.com>"
-SCRIPT_VERSION = "0.98.7"
+SCRIPT_VERSION = "0.99.0"
 SCRIPT_LICENSE = "MIT"
 SCRIPT_DESC = "Extends weechat for typing notification/search/etc on slack.com"
 
@@ -247,9 +247,6 @@ class SlackServer(object):
         if not w.buffer_search("", self.domain):
             self.buffer = w.buffer_new(self.domain, "buffer_input_cb", "", "", "")
             w.buffer_set(self.buffer, "nicklist", "1")
-
-            w.nicklist_add_group(self.buffer, '', NICK_GROUP_HERE, "weechat.color.nicklist_group", 1)
-            w.nicklist_add_group(self.buffer, '', NICK_GROUP_AWAY, "weechat.color.nicklist_group", 1)
 
     def create_slack_websocket(self, data):
         web_socket_url = data['url']
@@ -760,11 +757,11 @@ class User(object):
 
         if deleted:
             return
+        self.nicklist_pointer = w.nicklist_add_nick(server.buffer, "", self.name, self.color_name, "", "", 1)
         if self.presence == 'away':
-            ngroup = w.nicklist_search_group(server.buffer, "", NICK_GROUP_AWAY)
-        else:
-            ngroup = w.nicklist_search_group(server.buffer, "", NICK_GROUP_HERE)
-        self.nicklist_pointer = w.nicklist_add_nick(server.buffer, ngroup, self.name, self.color_name, "", "", 1)
+            w.nicklist_nick_set(self.server.buffer, self.nicklist_pointer, "visible", "0")
+        else;
+            w.nicklist_nick_set(self.server.buffer, self.nicklist_pointer, "visible", "1")
 #        w.nicklist_add_nick(server.buffer, "", self.formatted_name(), "", "", "", 1)
 
     def __str__(self):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -621,7 +621,6 @@ class Channel(object):
 
     def unset_scrolling(self):
         self.scrolling = False
-        self.buffer_redraw()
 
     def has_message(self, ts):
         return self.messages.count(ts) > 0

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -23,7 +23,7 @@ except:
 
 SCRIPT_NAME = "slack_extension"
 SCRIPT_AUTHOR = "Ryan Huber <rhuber@gmail.com>"
-SCRIPT_VERSION = "0.99.0"
+SCRIPT_VERSION = "0.99.1"
 SCRIPT_LICENSE = "MIT"
 SCRIPT_DESC = "Extends weechat for typing notification/search/etc on slack.com"
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -328,6 +328,7 @@ class Channel(object):
     """
     def __init__(self, server, name, identifier, active, last_read=0, prepend_name="", members=[], topic=""):
         self.name = prepend_name + name
+        self.current_short_name = prepend_name + name
         self.identifier = identifier
         self.active = active
         self.last_read = float(last_read)
@@ -384,7 +385,8 @@ class Channel(object):
                 w.buffer_set(self.channel_buffer, "localvar_set_type", 'private')
             else:
                 w.buffer_set(self.channel_buffer, "localvar_set_type", 'channel')
-            w.buffer_set(self.channel_buffer, "short_name", 'loading..')
+            #w.buffer_set(self.channel_buffer, "short_name", 'loading..')
+            w.buffer_set(self.channel_buffer, "short_name", self.name)
             buffer_list_update_next()
 
     def attach_buffer(self):
@@ -548,7 +550,8 @@ class Channel(object):
         else:
             new_name = self.name
         if self.channel_buffer:
-            if w.buffer_get_string(self.channel_buffer, "short_name") != (color + new_name):
+            if self.current_short_name != (color + new_name):
+                self.current_short_name = color + new_name
                 w.buffer_set(self.channel_buffer, "short_name", color + new_name)
 
 # deprecated in favor of redrawing the entire buffer
@@ -715,7 +718,9 @@ class DmChannel(Channel):
             new_name = self.server.users.find(self.name).formatted_name(' ', force_color)
 
         if self.channel_buffer:
-            w.buffer_set(self.channel_buffer, "short_name", new_name)
+            if self.current_short_name != new_name:
+                self.current_short_name = new_name
+                w.buffer_set(self.channel_buffer, "short_name", new_name)
 
     def update_nicklist(self):
         pass

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -912,11 +912,13 @@ def me_command_cb(data, current_buffer, args):
 
 
 def join_command_cb(data, current_buffer, args):
-    user = args.split()[1]
-    servers.find(current_domain_name()).users.find(user).open()
+    server = servers.find(current_domain_name())
     if channels.find(current_buffer) or servers.find(current_buffer):
-        channel = args.split()[1]
-        channel = servers.find(current_domain_name()).channels.find(channel)
+        arg = args.split()[1]
+        if server.channels.find(arg):
+            channel = server.channels.find(arg)
+        elif server.users.find(arg):
+            channel = server.users.find(arg)
         channel.open()
         if w.config_get_plugin('switch_buffer_on_join') != '0':
             w.buffer_set(channel.channel_buffer, "display", "1")

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -760,7 +760,7 @@ class User(object):
         self.nicklist_pointer = w.nicklist_add_nick(server.buffer, "", self.name, self.color_name, "", "", 1)
         if self.presence == 'away':
             w.nicklist_nick_set(self.server.buffer, self.nicklist_pointer, "visible", "0")
-        else;
+        else:
             w.nicklist_nick_set(self.server.buffer, self.nicklist_pointer, "visible", "1")
 #        w.nicklist_add_nick(server.buffer, "", self.formatted_name(), "", "", "", 1)
 


### PR DESCRIPTION
This (mostly) stops using buffer_redraw(), which re-rendered the entire buffer by clearing it and then passing every item in channel.messages through the process_message function.

Weechat uses posix seconds in message timestamps. Slack uses posix seconds + a unique index in case multiple messages come in the same second. In the case where there is only one message for a particular second, we just use hdata pointers to modify that line in the buffer. If we are unlucky and there are multiple messages at the same second that need modification, we fall back to redrawing the buffer.
