### PR TITLE
Add mpdm channel

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -291,7 +291,10 @@ class SlackServer(object):
             if "last_read" not in item:
                 item["last_read"] = 0
             if not item["is_archived"]:
-                self.add_channel(GroupChannel(self, item["name"], item["id"], item["is_open"], item["last_read"], "#", item["members"], item["topic"]["value"]))
+                if item["name"].startswith("mpdm-"):
+                    self.add_channel(MpdmChannel(self, item["name"], item["id"], item["is_open"], item["last_read"], "#", item["members"], item["topic"]["value"]))
+                else:
+                    self.add_channel(GroupChannel(self, item["name"], item["id"], item["is_open"], item["last_read"], "#", item["members"], item["topic"]["value"]))
         for item in data["ims"]:
             if "last_read" not in item:
                 item["last_read"] = 0
@@ -723,6 +726,12 @@ class GroupChannel(Channel):
         super(GroupChannel, self).__init__(server, name, identifier, active, last_read, prepend_name, members, topic)
         self.type = "group"
 
+class MpdmChannel(Channel):
+
+    def __init__(self, server, name, identifier, active, last_read=0, prepend_name="", members=[], topic=""):
+        name = ",".join("-".join(name.split("-")[1:-1]).split("--"))
+        super(MpdmChannel, self).__init__(server, name, identifier, active, last_read, prepend_name, members, topic)
+        self.type = "group"
 
 class DmChannel(Channel):
 


### PR DESCRIPTION
This adds a new channel type for mpdms which formats as `"#first,second,third"`

This includes the current user's username, which we may want to exclude.

Closes https://github.com/rawdigits/wee-slack/issues/133