### PR TITLE
Add unicode emojis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In Development
 
 Dependencies
 ------------
-  * WeeChat 1.3+ http://weechat.org/ 
+  * WeeChat 1.3+ http://weechat.org/
   * websocket-client https://pypi.python.org/pypi/websocket-client/
 
 Setup
@@ -101,7 +101,7 @@ If you don't want to store your API token in plaintext you can use the secure fe
 ```
 
 ##### Optional: If you would like to connect to multiple groups, use the above command with multiple tokens separated by commas. (NO SPACES)
-    
+
 ```
 /set plugins.var.python.slack_extension.slack_api_token [token1],[token2],[token3]
 ```
@@ -165,6 +165,11 @@ Turn off colorized nicks:
 /set plugins.var.python.slack_extension.colorize_nicks 0
 ```
 
+Disable unicode emojis support:
+```
+/set plugins.var.python.slack_extension.enable_emojis 0
+```
+
 Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. when using buffers.pl):
 ```
 /set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"
@@ -202,8 +207,3 @@ Support
 --------------
 
 wee-slack is provided without any warranty whatsoever, but you are welcome to ask questions in #wee-slack on freenode.
-
-
-
-
-    


### PR DESCRIPTION
Currently, emojis are rendered as string: (:simple_smile: ...). When a user overly uses them, it becomes very annoying to read even small messages.
The idea here is to use unicode emojis when slack-emoji patterns are found. This option is enabled by default, but can be disabled this way:

    /set plugins.var.python.slack_extension.enable_emojis 0

This commit only propose a small dict of emojis, but it is easy to add new ones.