### PR TITLE
Make /slack talk and friends work when server_alias is set

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -139,6 +139,7 @@ class SlackServer(object):
         self.communication_counter = 0
         self.message_buffer = {}
         self.ping_hook = None
+        self.alias = None
 
         self.identifier = None
         self.connect_to_slack()
@@ -167,7 +168,7 @@ class SlackServer(object):
         channels.append(channel, channel.get_aliases())
 
     def get_aliases(self):
-        aliases = [self.identifier, self.token, self.buffer]
+        aliases = filter(None, [self.identifier, self.token, self.buffer, self.alias])
         return aliases
 
     def find(self, name, attribute):
@@ -211,6 +212,7 @@ class SlackServer(object):
             alias = w.config_get_plugin("server_alias.{}".format(login_data["team"]["domain"]))
             if alias:
                 self.server_buffer_name = alias
+                self.alias = alias
             else:
                 self.server_buffer_name = self.domain
 


### PR DESCRIPTION
We need to add the short name as an alias so current_domain_name is
able to figure out which server the current buffer belongs to.

Fixes: #158