### PR TITLE
Support adding and removing reactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,11 @@ Delete previous message:
 s///
 ```
 
+Add a reaction to the nth last message. The number can be omitted and defaults to the last message. The `+` can be replaced with a `-` to remove a reaction instead.
+```
+3+:smile:
+```
+
 Turn off colorized nicks:
 ```
 /set plugins.var.python.slack_extension.colorize_nicks 0

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -324,10 +324,14 @@ class SlackServer(object):
             #w.prnt("", "%s\t%s" % (user, message))
 
 def buffer_input_cb(b, buffer, data):
-    if not data.startswith('s/') or data.startswith('+'):
+    reaction = re.match("(\d*)\+:(.*):", data)
+    if not reaction and not data.startswith('s/'):
         channel = channels.find(buffer)
         channel.send_message(data)
         #channel.buffer_prnt(channel.server.nick, data)
+    elif reaction:
+        channel = channels.find(buffer)
+        channel.send_reaction(int(reaction.group(1) or 1), reaction.group(2))
     elif data.count('/') == 3:
         old, new = data.split('/')[1:3]
         channel = channels.find(buffer)
@@ -693,6 +697,12 @@ class Channel(object):
             self.messages[message_index].remove_reaction(reaction)
             self.change_message(ts)
             return True
+
+    def send_reaction(self, msg_number, reaction):
+        if 0 < msg_number < len(self.messages):
+            timestamp = self.messages[-msg_number].message_json["ts"]
+            data = {"channel": self.identifier, "timestamp": timestamp, "name": reaction}
+            async_slack_api_request(self.server.domain, self.server.token, 'reactions.add', data)
 
     def change_previous_message(self, old, new):
         message = self.my_last_message()

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -324,20 +324,18 @@ class SlackServer(object):
             #w.prnt("", "%s\t%s" % (user, message))
 
 def buffer_input_cb(b, buffer, data):
+    channel = channels.find(buffer)
     reaction = re.match("(\d*)(\+|-):(.*):", data)
     if not reaction and not data.startswith('s/'):
-        channel = channels.find(buffer)
         channel.send_message(data)
         #channel.buffer_prnt(channel.server.nick, data)
     elif reaction:
-        channel = channels.find(buffer)
         if reaction.group(2) == "+":
             channel.send_add_reaction(int(reaction.group(1) or 1), reaction.group(3))
         elif reaction.group(2) == "-":
             channel.send_remove_reaction(int(reaction.group(1) or 1), reaction.group(3))
     elif data.count('/') == 3:
         old, new = data.split('/')[1:3]
-        channel = channels.find(buffer)
         channel.change_previous_message(old.decode("utf-8"), new.decode("utf-8"))
     channel.mark_read(True)
     return w.WEECHAT_RC_ERROR


### PR DESCRIPTION
A reaction can be added to the last message in the channel by writing

    +:reaction:

And removed by writing

    -:reaction:

Where reaction is the name of the reaction. This is the same syntax that
Slacks web interface uses.

Additionally, it supports sending a reaction to an earlier message by
prefixing the text with a number. The number is the number of the
message to add a reaction to, counting from the bottom. E.g. 1 is the
last message (same as without a number), 2 is the one before etc.

This fixes #155.