### PR TITLE
Show nicks for each reaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. wh
 /set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"
 ```
 
+Show who added each reaction. Makes reactions appear like `[:smile:(@nick1,@nick2)]` instead of `[:smile:2]`.
+```
+/set plugins.var.python.slack_extension.show_reaction_nicks on
+```
+
 Show typing notification in main bar (slack_typing_notice):
 ```
 /set weechat.bar.status.items [buffer_count],[buffer_plugin],buffer_number+:+buffer_name+{buffer_nicklist_count}+buffer_filter,[hotlist],completion,scroll,slack_typing_notice

--- a/README.md
+++ b/README.md
@@ -165,21 +165,6 @@ Add a reaction to the nth last message. The number can be omitted and defaults t
 3+:smile:
 ```
 
-Turn off colorized nicks:
-```
-/set plugins.var.python.slack_extension.colorize_nicks 0
-```
-
-Turn on colorized messages (messages match nick color):
-```
-/set plugins.var.python.slack_extension.colorize_nicks 1
-```
-
-Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. when using buffers.pl):
-```
-/set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"
-```
-
 Set all read markers to a specific time:
 ```
 /slack setallreadmarkers (time in epoch)
@@ -196,7 +181,22 @@ Debug mode:
 ```
 
 Optional settings
-----------------
+-----------------
+
+Turn off colorized nicks:
+```
+/set plugins.var.python.slack_extension.colorize_nicks 0
+```
+
+Turn on colorized messages (messages match nick color):
+```
+/set plugins.var.python.slack_extension.colorize_nicks 1
+```
+
+Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. when using buffers.pl):
+```
+/set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"
+```
 
 Show typing notification in main bar (slack_typing_notice):
 ```

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -938,12 +938,12 @@ class Message(object):
             found = False
             for r in self.message_json["reactions"]:
                 if r["name"] == reaction:
-                    r["users"].append(user)
+                    r["users"].add(user)
                     found = True
             if not found:
-                self.message_json["reactions"].append({u"name": reaction, u"users": [user]})
+                self.message_json["reactions"].append({u"name": reaction, u"users": {user}})
         else:
-            self.message_json["reactions"] = [{u"name": reaction, u"users": [user]}]
+            self.message_json["reactions"] = [{u"name": reaction, u"users": {user}}]
 
     def remove_reaction(self, reaction, user):
         if "reactions" in self.message_json:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -938,19 +938,17 @@ class Message(object):
             found = False
             for r in self.message_json["reactions"]:
                 if r["name"] == reaction:
-                    r["count"] += 1
                     r["users"].append(user)
                     found = True
             if not found:
-                self.message_json["reactions"].append({u"count": 1, u"name": reaction, u"users": [user]})
+                self.message_json["reactions"].append({u"name": reaction, u"users": [user]})
         else:
-            self.message_json["reactions"] = [{u"count": 1, u"name": reaction, u"users": [user]}]
+            self.message_json["reactions"] = [{u"name": reaction, u"users": [user]}]
 
     def remove_reaction(self, reaction, user):
         if "reactions" in self.message_json:
             for r in self.message_json["reactions"]:
                 if r["name"] == reaction:
-                    r["count"] -= 1
                     r["users"].remove(user)
         else:
             pass
@@ -1575,7 +1573,7 @@ def create_reaction_string(reactions):
     else:
         reaction_string = ' ['
         for r in reactions:
-            if r["count"] > 0:
+            if len(r["users"]) > 0:
                 count += 1
                 users = ",".join(resolve_ref("@{}".format(user)) for user in r["users"])
                 reaction_string += ":{}:({}) ".format(r["name"], users)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1575,8 +1575,12 @@ def create_reaction_string(reactions):
         for r in reactions:
             if len(r["users"]) > 0:
                 count += 1
-                users = ",".join(resolve_ref("@{}".format(user)) for user in r["users"])
-                reaction_string += ":{}:({}) ".format(r["name"], users)
+                if show_reaction_nicks:
+                    nicks = [resolve_ref("@{}".format(user)) for user in r["users"]]
+                    users = "({})".format(",".join(nicks))
+                else:
+                    users = len(r["users"])
+                reaction_string += ":{}:{} ".format(r["name"], users)
         reaction_string = reaction_string[:-1] + ']'
     if count == 0:
         reaction_string = ''
@@ -2150,7 +2154,7 @@ def create_slack_debug_buffer():
 
 def config_changed_cb(data, option, value):
     global slack_api_token, distracting_channels, colorize_nicks, colorize_private_chats, slack_debug, debug_mode, \
-        unfurl_ignore_alt_text, colorize_messages
+        unfurl_ignore_alt_text, colorize_messages, show_reaction_nicks
 
     slack_api_token = w.config_get_plugin("slack_api_token")
 
@@ -2164,6 +2168,7 @@ def config_changed_cb(data, option, value):
     if debug_mode != '' and debug_mode != 'false':
         create_slack_debug_buffer()
     colorize_private_chats = w.config_string_to_boolean(w.config_get_plugin("colorize_private_chats"))
+    show_reaction_nicks = w.config_string_to_boolean(w.config_get_plugin("show_reaction_nicks"))
 
     unfurl_ignore_alt_text = False
     if w.config_get_plugin('unfurl_ignore_alt_text') != "0":
@@ -2234,6 +2239,8 @@ if __name__ == "__main__":
                 w.config_set_plugin('unfurl_ignore_alt_text', "0")
             if not w.config_get_plugin('switch_buffer_on_join'):
                 w.config_set_plugin('switch_buffer_on_join', "1")
+            if not w.config_get_plugin('show_reaction_nicks'):
+                w.config_set_plugin('show_reaction_nicks', "0")
 
             if w.config_get_plugin('channels_not_on_current_server_color'):
                 w.config_option_unset('channels_not_on_current_server_color')


### PR DESCRIPTION
This adds an option of showing who added each reaction. Instead of e.g. `[:smile:1]`, it now shows `[:smile:(@trygveaa)]`.

In case someone thinks this takes up too much space, I made it optional with the config option `show_reaction_nicks`. That defaults to false, which makes the reactions appear just like before.