### PR TITLE
Return from update_nicklist if no channel_buffer

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -422,17 +422,19 @@ class Channel(object):
         self.server.channels.update_hashtable()
 
     def update_nicklist(self, user=None):
-        if self.channel_buffer:
-            w.buffer_set(self.channel_buffer, "nicklist", "1")
+        if not self.channel_buffer:
+            return
 
-            #create nicklists for the current channel if they don't exist
-            #if they do, use the existing pointer
-            here = w.nicklist_search_group(self.channel_buffer, '', NICK_GROUP_HERE)
-            if not here:
-                here = w.nicklist_add_group(self.channel_buffer, '', NICK_GROUP_HERE, "weechat.color.nicklist_group", 1)
-            afk = w.nicklist_search_group(self.channel_buffer, '', NICK_GROUP_AWAY)
-            if not afk:
-                afk = w.nicklist_add_group(self.channel_buffer, '', NICK_GROUP_AWAY, "weechat.color.nicklist_group", 1)
+        w.buffer_set(self.channel_buffer, "nicklist", "1")
+
+        #create nicklists for the current channel if they don't exist
+        #if they do, use the existing pointer
+        here = w.nicklist_search_group(self.channel_buffer, '', NICK_GROUP_HERE)
+        if not here:
+            here = w.nicklist_add_group(self.channel_buffer, '', NICK_GROUP_HERE, "weechat.color.nicklist_group", 1)
+        afk = w.nicklist_search_group(self.channel_buffer, '', NICK_GROUP_AWAY)
+        if not afk:
+            afk = w.nicklist_add_group(self.channel_buffer, '', NICK_GROUP_AWAY, "weechat.color.nicklist_group", 1)
 
         if user:
             user = self.members_table[user]


### PR DESCRIPTION
All code paths in this method requires channel_buffer, so we can return
in the start if it is falsy.

This fixes a bug where the here and afk variables were not set, but used
later.

This fixes #150.