### PR TITLE
Don't call buffer_set in im_marked if buffer is None

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1444,7 +1444,8 @@ def process_im_open(message_json):
 def process_im_marked(message_json):
     channel = channels.find(message_json["channel"])
     channel.mark_read(False)
-    w.buffer_set(channel.channel_buffer, "hotlist", "-1")
+    if channel.channel_buffer is not None:
+        w.buffer_set(channel.channel_buffer, "hotlist", "-1")
 
 
 def process_im_created(message_json):


### PR DESCRIPTION
process_im_marked may be called after process_im_close (e.g. when you do
/close in an im window). After process_im_close has run,
channel.channel_buffer is None, which makes the buffer_set fail.

This fixes #138 and #143.