### PR TITLE
Coloring 'prefix_same_nick' prefix the same as the preceding username…

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In Development
 
 Dependencies
 ------------
-  * WeeChat 1.3+ http://weechat.org/ 
+  * WeeChat 1.3+ http://weechat.org/
   * websocket-client https://pypi.python.org/pypi/websocket-client/
 
 Setup
@@ -101,7 +101,7 @@ If you don't want to store your API token in plaintext you can use the secure fe
 ```
 
 ##### Optional: If you would like to connect to multiple groups, use the above command with multiple tokens separated by commas. (NO SPACES)
-    
+
 ```
 /set plugins.var.python.slack_extension.slack_api_token [token1],[token2],[token3]
 ```
@@ -170,6 +170,11 @@ Turn off colorized nicks:
 /set plugins.var.python.slack_extension.colorize_nicks 0
 ```
 
+Turn on colorized messages (messages match nick color):
+```
+/set plugins.var.python.slack_extension.colorize_nicks 1
+```
+
 Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. when using buffers.pl):
 ```
 /set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"
@@ -211,4 +216,4 @@ wee-slack is provided without any warranty whatsoever, but you are welcome to as
 
 
 
-    
+

--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ Turn on colorized messages (messages match nick color):
 /set plugins.var.python.slack_extension.colorize_nicks 1
 ```
 
+Turn on highlighting of slack higlight words (@channel, @everyone):
+```
+/set plugins.var.python.slack_extension.slack_highlight_words 1
+```
+
 Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. when using buffers.pl):
 ```
 /set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -617,6 +617,10 @@ class Channel(object):
             set_read_marker = True
         elif message.find(self.server.nick.encode('utf-8')) > -1:
             tags = "notify_highlight"
+        elif slack_highlight_words and message.find("!channel".encode('utf-8')) > -1:
+            tags = "notify_highlight"
+        elif slack_highlight_words and message.find("!everyone".encode('utf-8')) > -1:
+            tags = "notify_highlight"
         elif user != self.server.nick and self.name in self.server.users:
             tags = "notify_private,notify_message"
         elif self.muted:
@@ -2115,7 +2119,7 @@ def create_slack_debug_buffer():
 
 
 def config_changed_cb(data, option, value):
-    global slack_api_token, distracting_channels, colorize_nicks, colorize_private_chats, slack_debug, debug_mode, \
+    global slack_api_token, distracting_channels, colorize_nicks, colorize_private_chats, slack_debug, debug_mode, slack_highlight_words, \
         unfurl_ignore_alt_text, colorize_messages
 
     slack_api_token = w.config_get_plugin("slack_api_token")
@@ -2126,6 +2130,7 @@ def config_changed_cb(data, option, value):
     distracting_channels = [x.strip() for x in w.config_get_plugin("distracting_channels").split(',')]
     colorize_nicks = w.config_get_plugin('colorize_nicks') == "1"
     colorize_messages = w.config_get_plugin("colorize_messages") == "1"
+    slack_highlight_words = w.config_get_plugin("slack_highlight_words") == "1"
     debug_mode = w.config_get_plugin("debug_mode").lower()
     if debug_mode != '' and debug_mode != 'false':
         create_slack_debug_buffer()
@@ -2192,6 +2197,8 @@ if __name__ == "__main__":
                 w.config_set_plugin('colorize_nicks', "1")
             if not w.config_get_plugin('colorize_messages'):
                 w.config_set_plugin('colorize_messages', "0")
+            if not w.config_get_plugin('slack_highlight_words'):
+                w.config_set_plugin('slack_highlight_words', "0")
             if not w.config_get_plugin('colorize_private_chats'):
                 w.config_set_plugin('colorize_private_chats', "0")
             if not w.config_get_plugin('trigger_value'):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -631,7 +631,10 @@ class Channel(object):
         if self.channel_buffer:
             prefix_same_nick = w.config_string(w.config_get('weechat.look.prefix_same_nick'))
             if user == self.last_active_user and prefix_same_nick != "":
-                name = prefix_same_nick
+                if colorize_nicks and self.server.users.find(user):
+                    name = self.server.users.find(user).color + prefix_same_nick
+                else:
+                    name = prefix_same_nick
             else:
                 nick_prefix = w.config_string(w.config_get('weechat.look.nick_prefix'))
                 nick_suffix = w.config_string(w.config_get('weechat.look.nick_suffix'))

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -652,11 +652,16 @@ class Channel(object):
             chat_color = w.config_string(w.config_get('weechat.color.chat'))
             if type(message) is not unicode:
               message = message.decode('UTF-8', 'replace')
+            curr_color = w.color(chat_color)
+            if colorize_nicks and colorize_messages and self.server.users.find(user):
+                curr_color = self.server.users.find(user).color
+            message = curr_color + message
             for user in self.server.users:
                 if user.name in message:
                     message = user.name_regex.sub(
-                        r'\1\2{}\3'.format(user.formatted_name() + w.color(chat_color)),
+                        r'\1\2{}\3'.format(user.formatted_name() + curr_color),
                         message)
+
             message = HTMLParser.HTMLParser().unescape(message)
             data = u"{}\t{}".format(name, message).encode('utf-8')
             w.prnt_date_tags(self.channel_buffer, time_int, tags, data)
@@ -2111,7 +2116,7 @@ def create_slack_debug_buffer():
 
 def config_changed_cb(data, option, value):
     global slack_api_token, distracting_channels, colorize_nicks, colorize_private_chats, slack_debug, debug_mode, \
-        unfurl_ignore_alt_text
+        unfurl_ignore_alt_text, colorize_messages
 
     slack_api_token = w.config_get_plugin("slack_api_token")
 
@@ -2120,6 +2125,7 @@ def config_changed_cb(data, option, value):
 
     distracting_channels = [x.strip() for x in w.config_get_plugin("distracting_channels").split(',')]
     colorize_nicks = w.config_get_plugin('colorize_nicks') == "1"
+    colorize_messages = w.config_get_plugin("colorize_messages") == "1"
     debug_mode = w.config_get_plugin("debug_mode").lower()
     if debug_mode != '' and debug_mode != 'false':
         create_slack_debug_buffer()
@@ -2184,6 +2190,8 @@ if __name__ == "__main__":
                 w.config_set_plugin('debug_mode', "")
             if not w.config_get_plugin('colorize_nicks'):
                 w.config_set_plugin('colorize_nicks', "1")
+            if not w.config_get_plugin('colorize_messages'):
+                w.config_set_plugin('colorize_messages', "0")
             if not w.config_get_plugin('colorize_private_chats'):
                 w.config_set_plugin('colorize_private_chats', "0")
             if not w.config_get_plugin('trigger_value'):


### PR DESCRIPTION
… it is replacing if 'colorize_nicks' is turned on.

Example:

![Colorized Prefixes](http://drop.bryangilbert.com/1bj3v.png)

IMO, this makes conversations a bit easier to follow when a prefix is defined.