### PR TITLE
Added option to colorize messages the same color as the sending nick …

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ In Development
 
 Dependencies
 ------------
-  * WeeChat 1.3+ http://weechat.org/ 
+  * WeeChat 1.3+ http://weechat.org/
   * websocket-client https://pypi.python.org/pypi/websocket-client/
 
 Setup
@@ -101,7 +101,7 @@ If you don't want to store your API token in plaintext you can use the secure fe
 ```
 
 ##### Optional: If you would like to connect to multiple groups, use the above command with multiple tokens separated by commas. (NO SPACES)
-    
+
 ```
 /set plugins.var.python.slack_extension.slack_api_token [token1],[token2],[token3]
 ```
@@ -170,6 +170,11 @@ Turn off colorized nicks:
 /set plugins.var.python.slack_extension.colorize_nicks 0
 ```
 
+Turn on colorized messages (messages match nick color):
+```
+/set plugins.var.python.slack_extension.colorize_nicks 1
+```
+
 Set channel prefix to something other than my-slack-subdomain.slack.com (e.g. when using buffers.pl):
 ```
 /set plugins.var.python.slack_extension.server_alias.my-slack-subdomain "mysub"
@@ -211,4 +216,4 @@ wee-slack is provided without any warranty whatsoever, but you are welcome to as
 
 
 
-    
+

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -649,11 +649,16 @@ class Channel(object):
             chat_color = w.config_string(w.config_get('weechat.color.chat'))
             if type(message) is not unicode:
               message = message.decode('UTF-8', 'replace')
+            curr_color = w.color(chat_color)
+            if colorize_nicks and colorize_messages and self.server.users.find(user):
+                curr_color = self.server.users.find(user).color
+            message = curr_color + message
             for user in self.server.users:
                 if user.name in message:
                     message = user.name_regex.sub(
-                        r'\1\2{}\3'.format(user.formatted_name() + w.color(chat_color)),
+                        r'\1\2{}\3'.format(user.formatted_name() + curr_color),
                         message)
+
             message = HTMLParser.HTMLParser().unescape(message)
             data = u"{}\t{}".format(name, message).encode('utf-8')
             w.prnt_date_tags(self.channel_buffer, time_int, tags, data)
@@ -2108,7 +2113,7 @@ def create_slack_debug_buffer():
 
 def config_changed_cb(data, option, value):
     global slack_api_token, distracting_channels, colorize_nicks, colorize_private_chats, slack_debug, debug_mode, \
-        unfurl_ignore_alt_text
+        unfurl_ignore_alt_text, colorize_messages
 
     slack_api_token = w.config_get_plugin("slack_api_token")
 
@@ -2117,6 +2122,7 @@ def config_changed_cb(data, option, value):
 
     distracting_channels = [x.strip() for x in w.config_get_plugin("distracting_channels").split(',')]
     colorize_nicks = w.config_get_plugin('colorize_nicks') == "1"
+    colorize_messages = w.config_get_plugin("colorize_messages") == "1"
     debug_mode = w.config_get_plugin("debug_mode").lower()
     if debug_mode != '' and debug_mode != 'false':
         create_slack_debug_buffer()
@@ -2181,6 +2187,8 @@ if __name__ == "__main__":
                 w.config_set_plugin('debug_mode', "")
             if not w.config_get_plugin('colorize_nicks'):
                 w.config_set_plugin('colorize_nicks', "1")
+            if not w.config_get_plugin('colorize_messages'):
+                w.config_set_plugin('colorize_messages', "0")
             if not w.config_get_plugin('colorize_private_chats'):
                 w.config_set_plugin('colorize_private_chats', "0")
             if not w.config_get_plugin('trigger_value'):


### PR DESCRIPTION
…(defaults to off)

Added new option 'colorize_messages' that defaults to off, that when turned on will result in all messages being colored the same as the nick of the sender. Doesn't interfere with coloring usernames in the messages, and I've added corresponding doc to the README.

Example:
![Colorized Messages](http://drop.bryangilbert.com/oqQt.png)

I missed this a lot when moving to wee-slack from using the irc gateway + a bouncer. This option effectively mimics the behavior of the 'colorize_lines.pl' plugin.