### PR TITLE
Coloring 'prefix_same_nick' prefix the same as the preceding username…

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -631,7 +631,10 @@ class Channel(object):
         if self.channel_buffer:
             prefix_same_nick = w.config_string(w.config_get('weechat.look.prefix_same_nick'))
             if user == self.last_active_user and prefix_same_nick != "":
-                name = prefix_same_nick
+                if colorize_nicks and self.server.users.find(user):
+                    name = self.server.users.find(user).color + prefix_same_nick
+                else:
+                    name = prefix_same_nick
             else:
                 nick_prefix = w.config_string(w.config_get('weechat.look.nick_prefix'))
                 nick_suffix = w.config_string(w.config_get('weechat.look.nick_suffix'))


### PR DESCRIPTION
… it is replacing if 'colorize_nicks' is turned on.

Example:

![Colorized Prefixes](http://drop.bryangilbert.com/1bj3v.png)

IMO, this makes conversations a bit easier to follow when a prefix is defined.