### PR TITLE
Prefix the server buffer name with slack instead of suffixing it

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -222,7 +222,7 @@ class SlackServer(object):
                 self.server_buffer_name = alias
                 self.alias = alias
             else:
-                self.server_buffer_name = self.domain
+                self.server_buffer_name = "slack." + login_data["team"]["domain"]
 
             self.nick = login_data["self"]["name"]
             self.create_local_buffer()


### PR DESCRIPTION
Instead of using the format `$team.slack.com` for the server buffer name,
change it to `slack.$team`. This makes it easier to see that the buffer is
a slack buffer.

Additionally, it makes it possible to set options where you specify the
start of the buffer name for all of the slack buffers. For example, it
makes it possible to set the option `logger.mask.python.slack` for
setting a logger file mask for all of the slack buffers.

This is the change I suggested in https://github.com/rawdigits/wee-slack/issues/144#issuecomment-202512332. I figured I'd make a PR for it, so it's not forgotten.