### PR TITLE
Ignore command not executed in a slack buffer

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -977,12 +977,25 @@ def me_command_cb(data, current_buffer, args):
     return w.WEECHAT_RC_OK
 
 
+# Wrap command_ functions that require they be performed in a slack buffer
+def slack_buffer_required(f):
+    @wraps(f)
+    def wrapper(current_buffer, *args, **kwargs):
+        server = servers.find(current_domain_name())
+        if not server:
+            return w.WEECHAT_RC_OK
+        return f(current_buffer, *args, **kwargs)
+    return wrapper
+
+
+@slack_buffer_required
 def join_command_cb(data, current_buffer, args):
     if command_talk(current_buffer, args.split()[1]):
         return w.WEECHAT_RC_OK_EAT
     else:
         return w.WEECHAT_RC_OK
 
+@slack_buffer_required
 def part_command_cb(data, current_buffer, args):
     if channels.find(current_buffer) or servers.find(current_buffer):
         args = args.split()
@@ -994,18 +1007,6 @@ def part_command_cb(data, current_buffer, args):
         return w.WEECHAT_RC_OK_EAT
     else:
         return w.WEECHAT_RC_OK
-
-
-# Wrap command_ functions that require they be performed in a slack buffer
-def slack_buffer_required(f):
-    @wraps(f)
-    def wrapper(current_buffer, *args, **kwargs):
-        server = servers.find(current_domain_name())
-        if not server:
-            w.prnt(current_buffer, "This command must be used in a slack buffer")
-            return
-        return f(current_buffer, *args, **kwargs)
-    return wrapper
 
 
 @slack_buffer_required
@@ -1282,6 +1283,7 @@ def command_openweb(current_buffer, args):
             w.buffer_set(channel_buffer, "title", data["topic"])
     return w.WEECHAT_RC_OK
 
+@slack_buffer_required
 def topic_command_cb(data, current_buffer, args):
     if command_topic(current_buffer, args.split(None, 1)[1]):
         return w.WEECHAT_RC_OK_EAT


### PR DESCRIPTION
Commands query, join, part, leave, topic are not specific to slack.
Using them in an irc context is valid and should not trigger errors
or messages.

Fixes #191 and #137 