### PR TITLE
Add @slack_buffer_required to command_join

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1068,6 +1068,8 @@ def command_talk(current_buffer, args):
     else:
         return False
 
+
+@slack_buffer_required
 def command_join(current_buffer, args):
     """
     Join the specified channel


### PR DESCRIPTION
This fixes a traceback when command_join is run outside of a slack
buffer.