### PR TITLE
Fix two tracebacks in command_talk

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1064,6 +1064,7 @@ def command_talk(current_buffer, args):
                     channel.create_buffer()
             else:
                 server.buffer_prnt("User or channel {} not found.".format(args))
+                return False
         if w.config_get_plugin('switch_buffer_on_join') != '0':
             w.buffer_set(channel.channel_buffer, "display", "1")
         return True

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1060,6 +1060,8 @@ def command_talk(current_buffer, args):
             user = server.users.find(args)
             if user:
                 user.create_dm_channel()
+                if channel.channel_buffer is None:
+                    channel.create_buffer()
             else:
                 server.buffer_prnt("User or channel {} not found.".format(args))
         if w.config_get_plugin('switch_buffer_on_join') != '0':


### PR DESCRIPTION
Both tracebacks occur when you attempt to /slack talk a username for which no
buffer currently exists, as command_talk attempts to set the buffer for a
nonexistant channel. See commit messages for further details.