### PR TITLE
Encode topics in utf-8, not ascii

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -541,7 +541,7 @@ class Channel(object):
         return " ".join(message)
 
     def set_topic(self, topic):
-        topic = topic.encode('ascii', 'ignore')
+        topic = topic.encode('utf-8')
         w.buffer_set(self.channel_buffer, "title", topic)
 
     def open(self, update_remote=True):


### PR DESCRIPTION
Utf-8 is already used for names and messages; it's now also the case for topics.