### PR TITLE
Fix error when sending messages to server query

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -339,6 +339,8 @@ class SlackServer(object):
 
 def buffer_input_cb(b, buffer, data):
     channel = channels.find(buffer)
+    if not channel:
+        return w.WEECHAT_RC_OK_EAT
     reaction = re.match("(\d*)(\+|-):(.*):", data)
     if not reaction and not data.startswith('s/'):
         channel.send_message(data)


### PR DESCRIPTION
```
python: stdout/stderr: Traceback (most recent call last):
python: stdout/stderr:   File "/home/bendem/.weechat/python/autoload/wee_slack.py", line 344, in buffer_input_cb
python: stdout/stderr:     channel.send_message(data)
python: stdout/stderr: AttributeError: 'NoneType' object has no attribute 'send_message'
python: error in function "buffer_input_cb"
```