### PR TITLE
Support passing additional tags to enable notification_center.py

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -427,7 +427,7 @@ class Channel(object):
         if channel_buffer != main_weechat_buffer:
             self.channel_buffer = channel_buffer
             w.buffer_set(self.channel_buffer, "localvar_set_nick", self.server.nick)
-#            w.buffer_set(self.channel_buffer, "highlight_words", self.server.nick)
+            w.buffer_set(self.channel_buffer, "highlight_words", self.server.nick)
         else:
             self.channel_buffer = None
         channels.update_hashtable()
@@ -622,13 +622,13 @@ class Channel(object):
         elif message.find(self.server.nick.encode('utf-8')) > -1:
             tags = ",notify_highlight,log1"
         elif user != self.server.nick and self.name in self.server.users:
-            tags = ",notify_private,notify_message,log1"
+            tags = ",notify_private,notify_message,log1,irc_privmsg"
         elif self.muted:
             tags = ",no_highlight,notify_none,logger_backlog_end"
         elif user in [x.strip() for x in w.prefix("join"), w.prefix("quit")]:
             tags = ",irc_smart_filter"
         else:
-            tags = ",notify_message,log1"
+            tags = ",notify_message,log1,irc_privmsg"
         #don't write these to local log files
         #tags += ",no_log"
         time_int = int(time_float)


### PR DESCRIPTION
This supports adding additional tags to enable notification_center.py to push said tagged notifiers to osx' notification center.

In response to: https://github.com/rawdigits/wee-slack/issues/211

It feels like there is/could/should be a better way to do this? Could just be my complete lack of full knowledge around this plugin.

I originally had settings to enable/disable highlighting, as well as customizing the highlights, beyond the ones you set in weechat's `irc.conf`. This however, proved to be useless as the notification_center.py plugin simply hooks into those existing highlights. Interestingly enough, though; `@here`/`!here` mentions in the channel WILL notify, perhaps that was already built in from the start and I missed that.

At any rate, please let me know where changes need/should be made.

Thanks for this awesome plugin. Slack was already pretty dang awesome, and this plugin simply puts it over the top. :)