### PR TITLE
Update README to mention location of the API token required

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ weechat
 ```
 /set plugins.var.python.slack_extension.slack_api_token [YOUR_SLACK_TOKEN]
 ```
-^^ (find this at https://api.slack.com/web)
+^^ (find this at https://api.slack.com/web behind the "Generate test tokens" button)
 
 If you don't want to store your API token in plaintext you can use the secure features of weechat:
 


### PR DESCRIPTION
This comes up in IRC all of the time and was not very obvious to me either.