### PR TITLE
consistently open mpdm the same way by handling the process_

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1629,6 +1629,16 @@ def process_group_archive(message_json):
     channel.detach_buffer()
 
 
+def process_mpim_close(message_json):
+    server = servers.find(message_json["_server"])
+    server.channels.find(message_json["channel"]).close(False)
+
+
+def process_mpim_open(message_json):
+    server = servers.find(message_json["_server"])
+    server.channels.find(message_json["channel"]).open()
+
+
 def process_im_close(message_json):
     server = servers.find(message_json["_server"])
     server.channels.find(message_json["channel"]).close(False)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1636,7 +1636,7 @@ def process_mpim_close(message_json):
 
 def process_mpim_open(message_json):
     server = servers.find(message_json["_server"])
-    server.channels.find(message_json["channel"]).open()
+    server.channels.find(message_json["channel"]).open(False)
 
 
 def process_im_close(message_json):

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -810,7 +810,7 @@ class GroupChannel(Channel):
 class MpdmChannel(Channel):
 
     def __init__(self, server, name, identifier, active, last_read=0, prepend_name="", members=[], topic=""):
-        name = ",".join("-".join(name.split("-")[1:-1]).split("--"))
+        name = "|".join("-".join(name.split("-")[1:-1]).split("--"))
         super(MpdmChannel, self).__init__(server, name, identifier, active, last_read, prepend_name, members, topic)
         self.type = "group"
 
@@ -1241,7 +1241,6 @@ def save_distracting_channels():
     w.config_set_plugin('distracting_channels', new)
 
 
-
 @slack_buffer_required
 def command_users(current_buffer, args):
     """
@@ -1619,7 +1618,10 @@ def process_group_joined(message_json):
         server.channels.find(message_json["channel"]["name"]).open(False)
     else:
         item = message_json["channel"]
-        server.add_channel(GroupChannel(server, item["name"], item["id"], item["is_open"], item["last_read"], "#", item["members"], item["topic"]["value"]))
+        if item["name"].startswith("mpdm-"):
+            server.add_channel(MpdmChannel(server, item["name"], item["id"], item["is_open"], item["last_read"], "#", item["members"], item["topic"]["value"]))
+        else:
+            server.add_channel(GroupChannel(server, item["name"], item["id"], item["is_open"], item["last_read"], "#", item["members"], item["topic"]["value"]))
 
 
 def process_group_archive(message_json):


### PR DESCRIPTION
We were parsing mpdm channel names during initial startup, but not when a new one was opened and we received a process_group_joined from slack. We now classify them as mpdm in both places for consistency. Also changed the seperator from "," to "|", because the comma caused problems with the distracting channels setting.