### PR TITLE
Add support for slash commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A WeeChat native client for Slack.com. Provides supplemental features only avail
 
 Features
 --------
+  * **New** Slash commands (including custom ones!)
   * **New** Upload to slack capabilities!
   * Emoji reactions!
   * Edited messages work just like the official clients, where the original message changes and has (edited) appended.
@@ -32,8 +33,6 @@ Features
   * Away/back status handling
   * Expands/shows metadata for things like tweets/links
   * Displays edited messages (slack.com irc mode currently doesn't show these)
-  * Slash commands (including custom ones!)
-
   * *Super fun* debug mode. See what the websocket is saying with `/slack debug`
 
 In Development

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Features
   * Away/back status handling
   * Expands/shows metadata for things like tweets/links
   * Displays edited messages (slack.com irc mode currently doesn't show these)
+  * Slash commands (including custom ones!)
 
   * *Super fun* debug mode. See what the websocket is saying with `/slack debug`
 
@@ -175,6 +176,11 @@ Set all read markers to a specific time:
 Upload a file to the current slack buffer:
 ```
 /slack upload [file_path]
+```
+
+Run a Slack slash command. Simply prepend `/slack slash` to what you'd type in the official clients.:
+```
+/slack slash /desiredcommand arg1 arg2 arg3
 ```
 
 Debug mode:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1326,7 +1326,7 @@ def command_slash(current_buffer, args):
     split_args = args.split(None, 1)
 
     command = split_args[0]
-    text = split_args[1] if len(args) > 0 else ""
+    text = split_args[1] if len(split_args) > 1 else ""
 
     if servers.find(domain).channels.find(channel):
         channel_identifier = servers.find(domain).channels.find(channel).identifier

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1323,10 +1323,12 @@ def command_slash(current_buffer, args):
         server.buffer_prnt("Usage: /slack slash /someslashcommand [arguments...].")
         return
 
-    aargs = args.split(None, 1)
+    split_args = args.split(None, 1)
 
-    command = aargs[0]
-    text = args[1] if len(args) > 1 else ""
+    command = split_args[0]
+    text = split_args[1] if len(args) > 0 else ""
+
+    server.buffer_prnt(text)
 
     if servers.find(domain).channels.find(channel):
         channel_identifier = servers.find(domain).channels.find(channel).identifier
@@ -1334,7 +1336,8 @@ def command_slash(current_buffer, args):
     if channel_identifier:
         async_slack_api_request(server.domain, server.token, 'chat.command', {'command': command, 'text': text, 'channel': channel_identifier})
     else:
-        server.buffer_prnt("User or channel {} not found.".format(args))
+        server.buffer_prnt("User or channel not found.")
+
 
 def command_flushcache(current_buffer, args):
     global message_cache

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1328,8 +1328,6 @@ def command_slash(current_buffer, args):
     command = split_args[0]
     text = split_args[1] if len(args) > 0 else ""
 
-    server.buffer_prnt(text)
-
     if servers.find(domain).channels.find(channel):
         channel_identifier = servers.find(domain).channels.find(channel).identifier
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1320,16 +1320,13 @@ def command_slash(current_buffer, args):
     domain = current_domain_name()
 
     if args is None:
-        server.buffer_prnt("Usage: /slack slash [/someslashcommand].")
+        server.buffer_prnt("Usage: /slack slash /someslashcommand [arguments...].")
         return
 
     aargs = args.split(None, 1)
 
     command = aargs[0]
-    if 1 < len(aargs):
-        text = aargs[1]
-    else:
-        text = ""
+    text = args[1] if len(args) > 1 else ""
 
     if servers.find(domain).channels.find(channel):
         channel_identifier = servers.find(domain).channels.find(channel).identifier

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1308,6 +1308,30 @@ def command_markread(current_buffer, args):
         servers.find(domain).channels.find(channel).mark_read()
 
 
+@slack_buffer_required
+def command_slash(current_buffer, args):
+    """
+    Support for custom slack commands
+    /slack slash /customcommand arg1 arg2 arg3
+    """
+    aargs = args.split(None, 1)
+
+    if len(aargs) == 0:
+        # XXX: whine
+        return
+    command = aargs[0]
+    text = aargs[1]
+
+    channel = current_buffer_name(short=True)
+    domain = current_domain_name()
+
+    if servers.find(domain).channels.find(channel):
+        channel_identifier = servers.find(domain).channels.find(channel).identifier
+
+    server = servers.find(current_domain_name())
+    async_slack_api_request(server.domain, server.token, 'chat.command', {'command': command, 'text': text, 'channel': channel_identifier})
+
+
 def command_flushcache(current_buffer, args):
     global message_cache
     message_cache = collections.defaultdict(list)

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1314,23 +1314,30 @@ def command_slash(current_buffer, args):
     Support for custom slack commands
     /slack slash /customcommand arg1 arg2 arg3
     """
-    aargs = args.split(None, 1)
 
-    if len(aargs) == 0:
-        # XXX: whine
-        return
-    command = aargs[0]
-    text = aargs[1]
-
+    server = servers.find(current_domain_name())
     channel = current_buffer_name(short=True)
     domain = current_domain_name()
+
+    if args is None:
+        server.buffer_prnt("Usage: /slack slash [/someslashcommand].")
+        return
+
+    aargs = args.split(None, 1)
+
+    command = aargs[0]
+    if 1 < len(aargs):
+        text = aargs[1]
+    else:
+        text = ""
 
     if servers.find(domain).channels.find(channel):
         channel_identifier = servers.find(domain).channels.find(channel).identifier
 
-    server = servers.find(current_domain_name())
-    async_slack_api_request(server.domain, server.token, 'chat.command', {'command': command, 'text': text, 'channel': channel_identifier})
-
+    if channel_identifier:
+        async_slack_api_request(server.domain, server.token, 'chat.command', {'command': command, 'text': text, 'channel': channel_identifier})
+    else:
+        server.buffer_prnt("User or channel {} not found.".format(args))
 
 def command_flushcache(current_buffer, args):
     global message_cache


### PR DESCRIPTION
This addresses #227 and allows the use of Slack slash commands, as below.

Simply prepend `/slack slash` to whatever you'd run via the official clients, and your command will be run. Example:

`/command arg1 arg2 arg3` simply becomes `/slack slash /command arg1 arg2 arg3`.

I've found it helpful to create an alias of `/command` => `/slack slash command` via weechat for the ones I use.