### PR TITLE
Leverage pytest.parametrize for test_unfurl

### DIFF
--- a/_pytest/test_unfurl.py
+++ b/_pytest/test_unfurl.py
@@ -1,36 +1,41 @@
 import wee_slack
 import pytest
-import json
 
 slack = wee_slack
 
-unfurl_map = [
-    { "input": "foo",
-      "output": "foo",
-    },
-    { "input": "<@U2147483697|@othernick>: foo",
-      "output": "@testuser: foo",
-      "ignore_alt_text": True
-    },
-    { "input": "foo <#C2147483705|#otherchannel> foo",
-      "output": "foo #otherchannel foo",
-    },
-    { "input": "foo <#C2147483705> foo",
-      "output": "foo #testchan foo",
-    },
-    { "input": "url: <https://example.com|example> suffix",
-      "output": "url: https://example.com (example) suffix",
-    },
-    { "input": "url: <https://example.com|example with spaces> suffix",
-      "output": "url: https://example.com (example with spaces) suffix",
-    },
-    { "input": "<@U2147483697|@othernick> multiple unfurl <https://example.com|example with spaces>",
-      "output": "@othernick multiple unfurl https://example.com (example with spaces)",
-    },
-    ]
 
-
-def test_unfurl_refs(myservers, mychannels, myusers):
+@pytest.mark.parametrize('case', (
+    {
+        'input': "foo",
+        'output': "foo",
+    },
+    {
+        'input': "<@U2147483697|@othernick>: foo",
+        'output': "@testuser: foo",
+        'ignore_alt_text': True,
+    },
+    {
+        'input': "foo <#C2147483705|#otherchannel> foo",
+        'output': "foo #otherchannel foo",
+    },
+    {
+        'input': "foo <#C2147483705> foo",
+        'output': "foo #testchan foo",
+    },
+    {
+        'input': "url: <https://example.com|example> suffix",
+        'output': "url: https://example.com (example) suffix",
+    },
+    {
+        'input': "url: <https://example.com|example with spaces> suffix",
+        'output': "url: https://example.com (example with spaces) suffix",
+    },
+    {
+        'input': "<@U2147483697|@othernick> multiple unfurl <https://example.com|example with spaces>",
+        'output': "@othernick multiple unfurl https://example.com (example with spaces)",
+    },
+))
+def test_unfurl_refs(myservers, mychannels, myusers, case):
     slack.servers = myservers
     slack.channels = mychannels
     slack.users = myusers
@@ -38,8 +43,4 @@ def test_unfurl_refs(myservers, mychannels, myusers):
     slack.servers[0].users = myusers
     print mychannels[0].identifier
 
-    for k in unfurl_map:
-        if "ignore_alt_text" in k:
-            assert slack.unfurl_refs(k["input"], ignore_alt_text=k["ignore_alt_text"]) == k["output"]
-        else:
-            assert slack.unfurl_refs(k["input"]) == k["output"]
+    assert slack.unfurl_refs(case['input'], ignore_alt_text=case.get('ignore_alt_text', False)) == case['output']


### PR DESCRIPTION
This provides nicer granular test cases rather than one whole test that
fails.

Just trying to get myself a bit more acquainted with the codebase before I make larger more meaningful contributions. :)

For context, the difference is:

```
_pytest/test_unfurl.py::test_unfurl_refs PASSED
```

vs

```
_pytest/test_unfurl.py::test_unfurl_refs[case0] PASSED
_pytest/test_unfurl.py::test_unfurl_refs[case1] PASSED
_pytest/test_unfurl.py::test_unfurl_refs[case2] PASSED
_pytest/test_unfurl.py::test_unfurl_refs[case3] PASSED
_pytest/test_unfurl.py::test_unfurl_refs[case4] PASSED
_pytest/test_unfurl.py::test_unfurl_refs[case5] PASSED
_pytest/test_unfurl.py::test_unfurl_refs[case6] PASSED
```