### PR TITLE
remove # from channel.name so /slack openweb works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -95,30 +95,20 @@ class SearchList(list):
         if name in self.hashtable:
             return self.hashtable[name]
         # this is a fallback to __eq__ if the item isn't in the hashtable already
-        if name in self:
+        if self.count(name) > 0:
             self.update_hashtable()
             return self[self.index(name)]
 
     def append(self, item, aliases=[]):
         super(SearchList, self).append(item)
-        self.update_hashtable(item)
+        self.update_hashtable()
 
-    def update_hashtable(self, item=None):
-        if item is not None:
-            try:
-                for alias in item.get_aliases():
+    def update_hashtable(self):
+        for child in self:
+            if hasattr(child, "get_aliases"):
+                for alias in child.get_aliases():
                     if alias is not None:
-                        self.hashtable[alias] = item
-            except AttributeError:
-                pass
-        else:
-            for child in self:
-                try:
-                    for alias in child.get_aliases():
-                        if alias is not None:
-                            self.hashtable[alias] = child
-                except AttributeError:
-                    pass
+                        self.hashtable[alias] = child
 
     def find_by_class(self, class_name):
         items = []
@@ -599,6 +589,7 @@ class Channel(object):
         if update_remote:
             if "join" in SLACK_API_TRANSLATOR[self.type]:
                 async_slack_api_request(self.server.domain, self.server.token, SLACK_API_TRANSLATOR[self.type]["join"], {"name": self.name.lstrip("#")})
+                async_slack_api_request(self.server.domain, self.server.token, SLACK_API_TRANSLATOR[self.type]["join"], {"user": users.find(self.name).identifier})
 
     def close(self, update_remote=True):
         # remove from cache so messages don't reappear when reconnecting
@@ -657,7 +648,6 @@ class Channel(object):
         set_read_marker = False
         time_float = float(time)
         tags = "nick_" + user
-        user_obj = self.server.users.find(user)
         # XXX: we should not set log1 for robots.
         if time_float != 0 and self.last_read >= time_float:
             tags += ",no_highlight,notify_none,logger_backlog_end"
@@ -678,8 +668,8 @@ class Channel(object):
         if self.channel_buffer:
             prefix_same_nick = w.config_string(w.config_get('weechat.look.prefix_same_nick'))
             if user == self.last_active_user and prefix_same_nick != "":
-                if colorize_nicks and user_obj:
-                    name = user_obj.color + prefix_same_nick
+                if colorize_nicks and self.server.users.find(user):
+                    name = self.server.users.find(user).color + prefix_same_nick
                 else:
                     name = prefix_same_nick
             else:
@@ -691,8 +681,8 @@ class Channel(object):
                 nick_suffix_color_name = w.config_string(w.config_get('weechat.color.chat_nick_prefix'))
                 nick_suffix_color = w.color(nick_suffix_color_name)
 
-                if user_obj:
-                    name = user_obj.formatted_name()
+                if self.server.users.find(user):
+                    name = self.server.users.find(user).formatted_name()
                     self.last_active_user = user
                     # XXX: handle bots properly here.
                 else:
@@ -705,8 +695,8 @@ class Channel(object):
             if type(message) is not unicode:
                 message = message.decode('UTF-8', 'replace')
             curr_color = w.color(chat_color)
-            if colorize_nicks and colorize_messages and user_obj:
-                curr_color = user_obj.color
+            if colorize_nicks and colorize_messages and self.server.users.find(user):
+                curr_color = self.server.users.find(user).color
             message = curr_color + message
             for user in self.server.users:
                 if user.name in message:
@@ -884,9 +874,7 @@ class User(object):
 
     def __eq__(self, compare_str):
         try:
-            if compare_str == self.name or compare_str == self.identifier:
-                return True
-            elif compare_str[0] == '@' and compare_str[1:] == self.name:
+            if compare_str == self.name or compare_str == "@" + self.name or compare_str == self.identifier:
                 return True
             else:
                 return False
@@ -1435,7 +1423,8 @@ def command_openweb(current_buffer, args):
     if trigger != "0":
         if args is None:
             channel = channels.find(current_buffer)
-            url = "{}/messages/{}".format(channel.server.server_buffer_name, channel.name)
+            name = re.sub('\#', '', channel.name)
+            url = "{}/messages/{}".format(channel.server.server_buffer_name, name)
             topic = w.buffer_get_string(channel.channel_buffer, "title")
             w.buffer_set(channel.channel_buffer, "title", "{}:{}".format(trigger, url))
             w.hook_timer(1000, 0, 1, "command_openweb", json.dumps({"topic": topic, "buffer": current_buffer}))
@@ -2100,11 +2089,6 @@ def buffer_closing_cb(signal, sig_type, data):
     return w.WEECHAT_RC_OK
 
 
-def buffer_opened_cb(signal, sig_type, data):
-    channels.update_hashtable()
-    return w.WEECHAT_RC_OK
-
-
 def buffer_switch_cb(signal, sig_type, data):
     global previous_buffer, hotlist
     # this is to see if we need to gray out things in the buffer list
@@ -2508,7 +2492,6 @@ if __name__ == "__main__":
             w.hook_timer(1000 * 60 * 29, 0, 0, "slack_never_away_cb", "")
             w.hook_timer(1000 * 60 * 5, 0, 0, "cache_write_cb", "")
             w.hook_signal('buffer_closing', "buffer_closing_cb", "")
-            w.hook_signal('buffer_opened', "buffer_opened_cb", "")
             w.hook_signal('buffer_switch', "buffer_switch_cb", "")
             w.hook_signal('window_switch', "buffer_switch_cb", "")
             w.hook_signal('input_text_changed', "typing_notification_cb", "")


### PR DESCRIPTION
`/slack openweb` won't open in the right channel due to a `#` being prepended to the channel name in the url. This uses regex to strip the `#` from`channel.name` before passing it to the url.

I've never done a pull request before, so please tell me if I can improve this somehow.