### PR TITLE
Disable cert validation (with warning) when no cafile available

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -66,6 +66,14 @@ if hasattr(ssl, "get_default_verify_paths") and callable(ssl.get_default_verify_
     ssl_defaults = ssl.get_default_verify_paths()
     if ssl_defaults.cafile is not None:
         sslopt_ca_certs = {'ca_certs': ssl_defaults.cafile}
+    else:
+        # Some systems don't have cafile, but capath. Websocket library doesn't
+        # support capath, so in that case we just hold our nose and disable
+        # certificate validation entirely.
+        w.prnt("", "slack: WARNING: system has no root certificates, or has "
+            "them in a format python-websocket-client doesn't support. "
+            "Disabling certificate validation for the connection to Slack.")
+        sslopt_ca_certs = {'cert_reqs': ssl.CERT_NONE}
 
 
 def dbg(message, fout=False, main_buffer=False):


### PR DESCRIPTION
ssl.get_default_verify_paths() can return cafile (a single unified file
containing the root certificates), capath (a directory containing one
file for each root certificate), or both. The websocket-client library
does not support capath.

In cases where cafile is not available, we now log a warning and disable
cert validation rather than giving up on connecting entirely.

Signed-off-by: Ben Kelly <bk@ancilla.ca>