### PR TITLE
typing: don't trigger typing indicator from weechat commands

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -2129,7 +2129,8 @@ def buffer_switch_cb(signal, sig_type, data):
 
 
 def typing_notification_cb(signal, sig_type, data):
-    if len(w.buffer_get_string(data, "input")) > 8:
+    msg = w.buffer_get_string(data, "input")
+    if len(msg) > 8 and msg[:1] != "/":
         global typing_timer
         now = time.time()
         if typing_timer + 4 < now:


### PR DESCRIPTION
Not sure if there's a better way to detect this, but doing things such as `/buffer #foobar` or `/window up`, etc, shouldn't be triggering Slack typing notifications since I'm just happily navigating around my terminal. So it seems like just ignoring if the input begins with `/` is reasonable.