### PR TITLE
Performance improvement and minor refactor

### DIFF
--- a/wee_slack.py
+++ b/wee_slack.py
@@ -817,10 +817,7 @@ class Channel(object):
         if self.active:
             for message in message_cache[self.identifier]:
                 process_message(json.loads(message), True)
-            if self.last_received is not None:
-                async_slack_api_request(self.server.domain, self.server.token, SLACK_API_TRANSLATOR[self.type]["history"], {"channel": self.identifier, "oldest": self.last_received, "count": BACKLOG_SIZE})
-            else:
-                async_slack_api_request(self.server.domain, self.server.token, SLACK_API_TRANSLATOR[self.type]["history"], {"channel": self.identifier, "count": BACKLOG_SIZE})
+            async_slack_api_request(self.server.domain, self.server.token, SLACK_API_TRANSLATOR[self.type]["history"], {"channel": self.identifier, "count": BACKLOG_SIZE})
         self.got_history = True
 
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -331,6 +331,7 @@ class SlackServer(object):
             self.add_bot(Bot(self, item["name"], item["id"], item["deleted"]))
 
         for item in data["channels"]:
+            item["is_open"] = item["is_member"]
             item["prepend_name"] = "#"
             if not item["is_archived"]:
                 self.add_channel(Channel(self, **item))
@@ -413,7 +414,7 @@ class Channel(object):
         self.name = kwargs.get('prepend_name', "") + kwargs.get('name')
         self.current_short_name = kwargs.get('prepend_name', "") + kwargs.get('name')
         self.identifier = kwargs.get('id', 0)
-        self.active = kwargs.get('is_member', True)
+        self.active = kwargs.get('is_open', False)
         self.last_read = float(kwargs.get('last_read', 0))
         self.members = set(kwargs.get('members', []))
         self.topic = kwargs.get('topic', {"value": ""})["value"]

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -514,10 +514,7 @@ class Channel(object):
             # since this is a change just remove it regardless of where it is
             w.nicklist_remove_nick(self.channel_buffer, nick)
             # now add it back in to whichever..
-            if user.presence == 'away':
-                w.nicklist_add_nick(self.channel_buffer, afk, user.name, user.color_name, "", "", 1)
-            else:
-                w.nicklist_add_nick(self.channel_buffer, here, user.name, user.color_name, "", "", 1)
+            w.nicklist_add_nick(self.channel_buffer, here, user.name, user.color_name, "", "", 1)
 
         # if we didn't get a user, build a complete list. this is expensive.
         else:
@@ -526,10 +523,7 @@ class Channel(object):
                     user = self.members_table[user]
                     if user.deleted:
                         continue
-                    if user.presence == 'away':
-                        w.nicklist_add_nick(self.channel_buffer, afk, user.name, user.color_name, "", "", 1)
-                    else:
-                        w.nicklist_add_nick(self.channel_buffer, here, user.name, user.color_name, "", "", 1)
+                    w.nicklist_add_nick(self.channel_buffer, here, user.name, user.color_name, "", "", 1)
             except Exception as e:
                 dbg("DEBUG: {} {} {}".format(self.identifier, self.name, e))
 
@@ -909,6 +903,7 @@ class User(object):
         return [self.name, "@" + self.name, self.identifier]
 
     def set_active(self):
+        return #temporarily noop this
         if self.deleted:
             return
 
@@ -922,6 +917,7 @@ class User(object):
             buffer_list_update_next()
 
     def set_inactive(self):
+        return #temporarily noop this
         if self.deleted:
             return
 

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -910,32 +910,33 @@ class User(object):
         return [self.name, "@" + self.name, self.identifier]
 
     def set_active(self):
-        return #temporarily noop this
-        if self.deleted:
-            return
+        if not self.deleted:
+            self.presence = "active"
+            dm_channel = self.server.channels.find(self.name)
+            if dm_channel and dm_channel.active:
+                buffer_list_update_next()
 
-        self.presence = "active"
+        return #temporarily noop this
         for channel in self.server.channels:
             if channel.has_user(self.identifier):
                 channel.update_nicklist(self.identifier)
         w.nicklist_nick_set(self.server.buffer, self.nicklist_pointer, "visible", "1")
-        dm_channel = self.server.channels.find(self.name)
-        if dm_channel and dm_channel.active:
-            buffer_list_update_next()
 
     def set_inactive(self):
+        if not self.deleted:
+            self.presence = "away"
+            dm_channel = self.server.channels.find(self.name)
+            if dm_channel and dm_channel.active:
+                buffer_list_update_next()
+
         return #temporarily noop this
         if self.deleted:
             return
 
-        self.presence = "away"
         for channel in self.server.channels:
             if channel.has_user(self.identifier):
                 channel.update_nicklist(self.identifier)
         w.nicklist_nick_set(self.server.buffer, self.nicklist_pointer, "visible", "0")
-        dm_channel = self.server.channels.find(self.name)
-        if dm_channel and dm_channel.active:
-            buffer_list_update_next()
 
     def update_color(self):
         if colorize_nicks:

--- a/wee_slack.py
+++ b/wee_slack.py
@@ -1683,9 +1683,9 @@ def process_group_joined(message_json):
         item = message_json["channel"]
         item["prepend_name"] = "#"
         if item["name"].startswith("mpdm-"):
-            self.add_channel(MpdmChannel(self, **item))
+            server.add_channel(MpdmChannel(server, **item))
         else:
-            self.add_channel(GroupChannel(self, **item))
+            server.add_channel(GroupChannel(server, **item))
 
 def process_group_archive(message_json):
     channel = server.channels.find(message_json["channel"])
@@ -1727,8 +1727,8 @@ def process_im_created(message_json):
         server.channels.find(channel_name).open(False)
     else:
         item = message_json["channel"]
-        item['name'] = self.users.find(item["user"]).name
-        self.add_channel(DmChannel(self, **item))
+        item['name'] = server.users.find(item["user"]).name
+        server.add_channel(DmChannel(server, **item))
     server.buffer_prnt("New direct message channel created: {}".format(item["name"]))
 
 


### PR DESCRIPTION
This PR does a few things:

1) Nicklists no longer change based on presence. The distinction between here/away still exists in usernames for open DM channels, but not for nicklists. The cpu overhead for maintaining every nicklist in many channels was very high for channels/teams with many users, and the value of having a nicklist in Slack is probably low.

2) Only load channel history the first time you switch to that buffer. In previous versions, we loaded channel history for each of your current slack channels. This makes startup time pretty bad for people on many teams or in many channels. This change took my average start time from > 60 seconds to about 10 seconds to connect to 44 Slack teams.

3) I finally switched the different channel objects to use kwargs, which makes them much easier to modify/use.